### PR TITLE
Service pause issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-22.0.1
-    - android-22
+    - build-tools-25.0.3
+    - android-25
     - extra-android-m2repository
     - extra-android-support
     - extra-google-google_play_services

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ To add device types to the passive remote monitoring Android app, create a plugi
     ```
     Once the schemas are published as part of the central schemas repository, you can remove the generated files again. Do not publish a non-alpha version of your plugin without the central schemas being published, otherwise there may be class conflicts later on.
 2. Create a new package `org.radarcns.mydevicetype`. In that package, create classes that:
-  - implement `org.radarcns.android.device.DeviceManager` to connect to a device and collect its data.
-  - implement `org.radarcns.android.DeviceState` to keep the current state of the device.
-  - subclass `org.radarcns.android.device.DeviceService` to run the device manager in.
-  - subclass a singleton `org.radarcns.android.device.DeviceTopics` that contains all Kafka topics that the wearable will generate.
-  - subclass a `org.radarcns.android.device.DeviceServiceProvider` that exposes the new service.
+    - implement `org.radarcns.android.device.DeviceManager` to connect to a device and collect its data.
+    - implement `org.radarcns.android.DeviceState` to keep the current state of the device.
+    - subclass `org.radarcns.android.device.DeviceService` to run the device manager in.
+    - subclass a singleton `org.radarcns.android.device.DeviceTopics` that contains all Kafka topics that the wearable will generate.
+    - subclass a `org.radarcns.android.device.DeviceServiceProvider` that exposes the new service.
 3. Add a new service element to `AndroidManifest.xml`, referencing the newly created device service. Also add all the required permissions there
 4. Add the `DeviceServiceProvider` you just created to the `device_services_to_connect` property in `app/src/main/res/xml/remote_config_defaults.xml`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 22
         versionCode 3
-        versionName '0.2-SNAPSHOT'
+        versionName '0.1.1-SNAPSHOT'
     }
     lintOptions {
         abortOnError false

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,12 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 22
+        minSdkVersion 21
+        targetSdkVersion 25
         versionCode 3
         versionName '0.1.1-SNAPSHOT'
     }
@@ -66,7 +66,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.2.0'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'
     compile 'org.apache.avro:avro:1.8.1'
     compile 'org.xerial.snappy:snappy-java:1.1.2.6'

--- a/src/main/java/org/radarcns/android/MainActivity.java
+++ b/src/main/java/org/radarcns/android/MainActivity.java
@@ -309,9 +309,9 @@ public abstract class MainActivity extends AppCompatActivity {
         getHandler().post(new Runnable() {
             @Override
             public void run() {
-                for (DeviceServiceProvider connection : mConnections) {
-                    if (connection.isBound()) {
-                        connection.unbind();
+                for (DeviceServiceProvider provider : mConnections) {
+                    if (provider.isBound()) {
+                        provider.unbind();
                     }
                 }
             }

--- a/src/main/java/org/radarcns/android/MainActivity.java
+++ b/src/main/java/org/radarcns/android/MainActivity.java
@@ -16,6 +16,7 @@
 
 package org.radarcns.android;
 
+import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -23,7 +24,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -32,7 +32,6 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -63,7 +62,7 @@ import static org.radarcns.android.device.DeviceService.DEVICE_STATUS_NAME;
 
 /** Base MainActivity class. It manages the services to collect the data and starts up a view. To
  * create an application, extend this class and override the abstract methods. */
-public abstract class MainActivity extends AppCompatActivity {
+public abstract class MainActivity extends Activity {
     private static final Logger logger = LoggerFactory.getLogger(MainActivity.class);
 
     private static final int REQUEST_ENABLE_PERMISSIONS = 2;
@@ -166,11 +165,6 @@ public abstract class MainActivity extends AppCompatActivity {
         latestNumberOfRecordsSent = new TimedInt();
     }
 
-    @Override
-    public boolean supportRequestWindowFeature(int featureId) {
-        return super.supportRequestWindowFeature(featureId);
-    }
-
     /**
      * Create a RadarConfiguration object. At implementation, the Firebase version needs to be set
      * for this.
@@ -234,9 +228,7 @@ public abstract class MainActivity extends AppCompatActivity {
             }
         };
 
-        if (getApplicationInfo().targetSdkVersion > Build.VERSION_CODES.LOLLIPOP_MR1) {
-            checkPermissions();
-        }
+        checkPermissions();
     }
 
     /**
@@ -460,6 +452,7 @@ public abstract class MainActivity extends AppCompatActivity {
         List<String> permissionsToRequest = new ArrayList<>();
         for (String permission : permissions) {
             if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
+                logger.info("Need to request permission for {}", permission);
                 permissionsToRequest.add(permission);
             }
         }
@@ -474,13 +467,15 @@ public abstract class MainActivity extends AppCompatActivity {
     public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == REQUEST_ENABLE_PERMISSIONS) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                // Permission granted.
-                startScanning();
-            } else {
-                // User refused to grant permission.
-                Boast.makeText(this, "Cannot connect to device plugin without proper permissions", Toast.LENGTH_LONG).show();
+            for (int i = 0; i < permissions.length; i++) {
+                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                    logger.info("Granted permission {}", permissions[i]);
+                } else {
+                    logger.info("Denied permission {}", permissions[i]);
+                }
             }
+            // Permission granted.
+            startScanning();
         }
     }
 

--- a/src/main/java/org/radarcns/android/RadarConfiguration.java
+++ b/src/main/java/org/radarcns/android/RadarConfiguration.java
@@ -65,6 +65,7 @@ public class RadarConfiguration {
     public static final String DEVICE_SERVICES_TO_CONNECT = "device_services_to_connect";
     public static final String KAFKA_UPLOAD_MINIMUM_BATTERY_LEVEL = "kafka_upload_minimum_battery_level";
     public static final String MAX_CACHE_SIZE = "cache_max_size_bytes";
+    public static final String SEND_ONLY_WITH_WIFI = "send_only_with_wifi";
 
     public static final Pattern IS_TRUE = Pattern.compile(
             "^(1|true|t|yes|y|on)$", CASE_INSENSITIVE);
@@ -84,11 +85,11 @@ public class RadarConfiguration {
             KAFKA_CLEAN_RATE_KEY, SENDER_CONNECTION_TIMEOUT_KEY, DATA_RETENTION_KEY,
             FIREBASE_FETCH_TIMEOUT_MS_KEY));
 
-    public static final Set<String> INT_VALUES = Collections.singleton(
-            KAFKA_RECORDS_SEND_LIMIT_KEY);
+    public static final Set<String> INT_VALUES = new HashSet<>(Arrays.asList(
+            KAFKA_RECORDS_SEND_LIMIT_KEY, MAX_CACHE_SIZE));
 
-    public static final Set<String> BOOLEAN_VALUES = Collections.singleton(
-            CONDENSED_DISPLAY_KEY);
+    public static final Set<String> BOOLEAN_VALUES = new HashSet<>(Arrays.asList(
+            CONDENSED_DISPLAY_KEY, SEND_ONLY_WITH_WIFI));
 
     public static final Set<String> FLOAT_VALUES = Collections.singleton(
             KAFKA_UPLOAD_MINIMUM_BATTERY_LEVEL);
@@ -492,6 +493,10 @@ public class RadarConfiguration {
 
     public static int getIntExtra(Bundle bundle, String key, int defaultValue) {
         return bundle.getInt(RADAR_PREFIX + key, defaultValue);
+    }
+
+    public static boolean getBooleanExtra(Bundle bundle, String key, boolean defaultValue) {
+        return bundle.getBoolean(RADAR_PREFIX + key, defaultValue);
     }
 
     public static int getIntExtra(Bundle bundle, String key) {

--- a/src/main/java/org/radarcns/android/RadarConfiguration.java
+++ b/src/main/java/org/radarcns/android/RadarConfiguration.java
@@ -60,6 +60,7 @@ public class RadarConfiguration {
     public static final String START_AT_BOOT = "start_at_boot";
     public static final String DEVICE_SERVICES_TO_CONNECT = "device_services_to_connect";
     public static final String KAFKA_UPLOAD_MINIMUM_BATTERY_LEVEL = "kafka_upload_minimum_battery_level";
+    public static final String MAX_CACHE_SIZE = "cache_max_size_bytes";
 
     public static final Pattern IS_TRUE = Pattern.compile(
             "^(1|true|t|yes|y|on)$", CASE_INSENSITIVE);

--- a/src/main/java/org/radarcns/android/RadarConfiguration.java
+++ b/src/main/java/org/radarcns/android/RadarConfiguration.java
@@ -18,6 +18,7 @@ package org.radarcns.android;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -35,12 +36,15 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 public class RadarConfiguration {
+    private static final Object SYNC_PREFS_OBJECT = new Object();
+
     public static final String RADAR_PREFIX = "org.radarcns.android.";
 
     public static final String KAFKA_REST_PROXY_URL_KEY = "kafka_rest_proxy_url";
@@ -512,5 +516,18 @@ public class RadarConfiguration {
 
     public static float getFloatExtra(Bundle bundle, String key) {
         return bundle.getFloat(RADAR_PREFIX + key);
+    }
+
+    public static String getOrSetUUID(@NonNull Context context, String key) {
+        SharedPreferences prefs = context.getSharedPreferences("global", Context.MODE_PRIVATE);
+        String uuid;
+        synchronized (SYNC_PREFS_OBJECT) {
+            uuid = prefs.getString(key, null);
+            if (uuid == null) {
+                uuid = UUID.randomUUID().toString();
+                prefs.edit().putString(key, uuid).apply();
+            }
+        }
+        return uuid;
     }
 }

--- a/src/main/java/org/radarcns/android/data/TableDataHandler.java
+++ b/src/main/java/org/radarcns/android/data/TableDataHandler.java
@@ -213,15 +213,9 @@ public class TableDataHandler implements DataHandler<MeasurementKey, SpecificRec
             batteryLevelReceiver.unregister();
         }
         if (this.submitter != null) {
-            try {
-                this.submitter.close();
-                this.submitter.join(5_000L);
-            } catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-            } finally {
-                this.submitter = null;
-                this.sender = null;
-            }
+            this.submitter.close();  // will also close sender
+            this.submitter = null;
+            this.sender = null;
         }
         clean();
         for (DataCache<MeasurementKey, ? extends SpecificRecord> table : tables.values()) {

--- a/src/main/java/org/radarcns/android/device/BaseServiceConnection.java
+++ b/src/main/java/org/radarcns/android/device/BaseServiceConnection.java
@@ -189,12 +189,10 @@ public class BaseServiceConnection<S extends BaseDeviceState> implements Service
 
     @Override
     public void onServiceDisconnected(ComponentName className) {
-        // Do NOT set deviceName to null. This causes loss of the name if application loses
-        // focus [MM 2016-11-16]
-
         // only do these steps once
-        if (getServiceBinder() != null) {
+        if (hasService()) {
             synchronized (this) {
+                deviceName = null;
                 serviceBinder = null;
                 deviceStatus = DeviceStatusListener.Status.DISCONNECTED;
             }

--- a/src/main/java/org/radarcns/android/device/DeviceService.java
+++ b/src/main/java/org/radarcns/android/device/DeviceService.java
@@ -68,6 +68,7 @@ import static org.radarcns.android.RadarConfiguration.KAFKA_UPLOAD_RATE_KEY;
 import static org.radarcns.android.RadarConfiguration.MAX_CACHE_SIZE;
 import static org.radarcns.android.RadarConfiguration.SCHEMA_REGISTRY_URL_KEY;
 import static org.radarcns.android.RadarConfiguration.SENDER_CONNECTION_TIMEOUT_KEY;
+import static org.radarcns.android.RadarConfiguration.SEND_ONLY_WITH_WIFI;
 
 /**
  * A service that manages a DeviceManager and a TableDataHandler to send store the data of a
@@ -560,6 +561,9 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
             }
         }
 
+        boolean sendOnlyWithWifi = RadarConfiguration.getBooleanExtra(
+                bundle, SEND_ONLY_WITH_WIFI, true);
+
         boolean newlyCreated;
         synchronized (this) {
             if (dataHandler == null) {
@@ -567,7 +571,8 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
                         bundle, MAX_CACHE_SIZE, Integer.MAX_VALUE);
                 try {
                     dataHandler = new TableDataHandler(
-                            this, kafkaConfig, remoteSchemaRetriever, getCachedTopics(), maxBytes);
+                            this, kafkaConfig, remoteSchemaRetriever, getCachedTopics(), maxBytes,
+                            sendOnlyWithWifi);
                     newlyCreated = true;
                 } catch (IOException ex) {
                     logger.error("Failed to instantiate Data Handler", ex);
@@ -587,6 +592,8 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
                 localDataHandler.setSchemaRetriever(remoteSchemaRetriever);
             }
         }
+
+        localDataHandler.setSendOnlyWithWifi(sendOnlyWithWifi);
 
         if (RadarConfiguration.hasExtra(bundle, DATA_RETENTION_KEY)) {
             localDataHandler.setDataRetention(

--- a/src/main/java/org/radarcns/android/device/DeviceService.java
+++ b/src/main/java/org/radarcns/android/device/DeviceService.java
@@ -183,6 +183,7 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
 
     @Override
     public void onRebind(Intent intent) {
+        logger.info("Received (re)bind in {}", this);
         numberOfActivitiesBound.incrementAndGet();
         if (intent != null) {
             onInvocation(intent.getExtras());
@@ -191,6 +192,7 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
 
     @Override
     public boolean onUnbind(Intent intent) {
+        logger.info("Received unbind in {}", this);
         int startId = -1;
         synchronized (this) {
             if (numberOfActivitiesBound.decrementAndGet() == 0 && !isConnected) {
@@ -198,6 +200,7 @@ public abstract class DeviceService extends Service implements DeviceStatusListe
             }
         }
         if (startId != -1) {
+            logger.info("Stopping self if latest start ID was {}", latestStartId);
             stopSelf(latestStartId);
         }
         return true;

--- a/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
+++ b/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
@@ -40,6 +40,7 @@ import static org.radarcns.android.RadarConfiguration.KAFKA_UPLOAD_RATE_KEY;
 import static org.radarcns.android.RadarConfiguration.MAX_CACHE_SIZE;
 import static org.radarcns.android.RadarConfiguration.SCHEMA_REGISTRY_URL_KEY;
 import static org.radarcns.android.RadarConfiguration.SENDER_CONNECTION_TIMEOUT_KEY;
+import static org.radarcns.android.RadarConfiguration.SEND_ONLY_WITH_WIFI;
 
 /**
  * RADAR service provider, to bind and configure to a service. It is not thread-safe.
@@ -190,7 +191,7 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
         config.putExtras(bundle,
                 KAFKA_REST_PROXY_URL_KEY, SCHEMA_REGISTRY_URL_KEY, DEFAULT_GROUP_ID_KEY,
                 KAFKA_UPLOAD_RATE_KEY, KAFKA_CLEAN_RATE_KEY, KAFKA_RECORDS_SEND_LIMIT_KEY,
-                SENDER_CONNECTION_TIMEOUT_KEY, MAX_CACHE_SIZE);
+                SENDER_CONNECTION_TIMEOUT_KEY, MAX_CACHE_SIZE, SEND_ONLY_WITH_WIFI);
     }
 
     /**

--- a/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
+++ b/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
@@ -32,6 +32,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Scanner;
 
+import static org.radarcns.android.RadarConfiguration.DEFAULT_GROUP_ID_KEY;
+import static org.radarcns.android.RadarConfiguration.KAFKA_CLEAN_RATE_KEY;
+import static org.radarcns.android.RadarConfiguration.KAFKA_RECORDS_SEND_LIMIT_KEY;
+import static org.radarcns.android.RadarConfiguration.KAFKA_REST_PROXY_URL_KEY;
+import static org.radarcns.android.RadarConfiguration.KAFKA_UPLOAD_RATE_KEY;
+import static org.radarcns.android.RadarConfiguration.MAX_CACHE_SIZE;
+import static org.radarcns.android.RadarConfiguration.SCHEMA_REGISTRY_URL_KEY;
+import static org.radarcns.android.RadarConfiguration.SENDER_CONNECTION_TIMEOUT_KEY;
+
 /**
  * RADAR service provider, to bind and configure to a service. It is not thread-safe.
  * @param <T> state that the Service will provide.
@@ -179,9 +188,9 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
     protected void configure(Bundle bundle) {
         // Add the default configuration parameters given to the service intents
         config.putExtras(bundle,
-                RadarConfiguration.KAFKA_REST_PROXY_URL_KEY, RadarConfiguration.SCHEMA_REGISTRY_URL_KEY, RadarConfiguration.DEFAULT_GROUP_ID_KEY,
-                RadarConfiguration.KAFKA_UPLOAD_RATE_KEY, RadarConfiguration.KAFKA_CLEAN_RATE_KEY, RadarConfiguration.KAFKA_RECORDS_SEND_LIMIT_KEY,
-                RadarConfiguration.SENDER_CONNECTION_TIMEOUT_KEY);
+                KAFKA_REST_PROXY_URL_KEY, SCHEMA_REGISTRY_URL_KEY, DEFAULT_GROUP_ID_KEY,
+                KAFKA_UPLOAD_RATE_KEY, KAFKA_CLEAN_RATE_KEY, KAFKA_RECORDS_SEND_LIMIT_KEY,
+                SENDER_CONNECTION_TIMEOUT_KEY, MAX_CACHE_SIZE);
     }
 
     /**

--- a/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
+++ b/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
@@ -24,6 +24,8 @@ import android.support.annotation.NonNull;
 
 import org.radarcns.android.MainActivity;
 import org.radarcns.android.RadarConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +37,8 @@ import java.util.Scanner;
  * @param <T> state that the Service will provide.
  */
 public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
+    private static final Logger logger = LoggerFactory.getLogger(DeviceServiceProvider.class);
+
     private MainActivity activity;
     private RadarConfiguration config;
     private DeviceServiceConnection<T> connection;
@@ -120,6 +124,7 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
         if (bound) {
             throw new IllegalStateException("Service is already bound");
         }
+        logger.info("Binding {}", this);
         Intent intent = new Intent(activity, getServiceClass());
         Bundle extras = new Bundle();
         configure(extras);
@@ -142,6 +147,7 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
         if (!bound) {
             throw new IllegalStateException("Service is not bound");
         }
+        logger.info("Unbinding {}", this);
         bound = false;
         activity.unbindService(connection);
         connection.onServiceDisconnected(null);

--- a/src/main/java/org/radarcns/android/kafka/KafkaConnectionChecker.java
+++ b/src/main/java/org/radarcns/android/kafka/KafkaConnectionChecker.java
@@ -16,6 +16,7 @@
 
 package org.radarcns.android.kafka;
 
+import org.radarcns.producer.KafkaSender;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.radarcns.producer.KafkaSender;
 
 /**
  * Checks the connection of a sender.
@@ -33,7 +33,7 @@ import org.radarcns.producer.KafkaSender;
  * It does so using two mechanisms: a regular heartbeat signal when the connection is assumed to be
  * present, and a exponential back-off mechanism if the connection is severed. If the connection is
  * assessed to be present through another mechanism, {@link #didConnect()} should be called,
- * conversely, if it is assessed to be severed, {@link #didDisconnect(IOException)} shoud be
+ * conversely, if it is assessed to be severed, {@link #didDisconnect(IOException)} should be
  * called.
  */
 class KafkaConnectionChecker implements Runnable {

--- a/src/main/java/org/radarcns/android/kafka/KafkaDataSubmitter.java
+++ b/src/main/java/org/radarcns/android/kafka/KafkaDataSubmitter.java
@@ -112,11 +112,15 @@ public class KafkaDataSubmitter<K, V> implements Closeable {
 
     /** Set upload rate in seconds. */
     public final synchronized void setUploadRate(long period) {
+        long newUploadRate = period * 1000L;
+        if (this.uploadRate == newUploadRate) {
+            return;
+        }
+        this.uploadRate = newUploadRate;
         if (uploadFuture != null) {
             uploadFuture.cancel(false);
             uploadIfNeededFuture.cancel(false);
         }
-        this.uploadRate = period * 1000L;
         // Get upload frequency from system property
         uploadFuture = executor.scheduleAtFixedRate(new Runnable() {
             Set<AvroTopic<K, ? extends V>> topicsToSend = Collections.emptySet();

--- a/src/main/java/org/radarcns/android/util/BatteryLevelReceiver.java
+++ b/src/main/java/org/radarcns/android/util/BatteryLevelReceiver.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import static android.content.Intent.ACTION_BATTERY_CHANGED;
+import static android.os.BatteryManager.EXTRA_LEVEL;
+import static android.os.BatteryManager.EXTRA_PLUGGED;
+import static android.os.BatteryManager.EXTRA_SCALE;
+
+/** Keep track of battery level events */
+public class BatteryLevelReceiver extends SpecificReceiver {
+    private final BatteryLevelListener listener;
+    private float level;
+    private boolean isPlugged;
+
+    public BatteryLevelReceiver(@NonNull Context context, BatteryLevelListener listener) {
+        super(context);
+        this.listener = listener;
+        this.level = 1.0f;
+        this.isPlugged = true;
+    }
+
+    @Override
+    protected String getAction() {
+        return ACTION_BATTERY_CHANGED;
+    }
+
+    @Override
+    protected void onSpecificReceive(Intent intent) {
+        int level = intent.getIntExtra(EXTRA_LEVEL, -1);
+        int scale = intent.getIntExtra(EXTRA_SCALE, -1);
+
+        this.level = level / (float)scale;
+        this.isPlugged = intent.getIntExtra(EXTRA_PLUGGED, 0) > 0;
+
+        if (listener != null) {
+            listener.onBatteryLevelChanged(this.level, this.isPlugged);
+        }
+    }
+
+    public float getLevel() {
+        return level;
+    }
+
+    public boolean isPlugged() {
+        return isPlugged;
+    }
+
+    public boolean hasMinimumLevel(float minLevel) {
+        return level >= minLevel || isPlugged;
+    }
+
+    public interface BatteryLevelListener {
+        void onBatteryLevelChanged(float level, boolean isPlugged);
+    }
+}

--- a/src/main/java/org/radarcns/android/util/BatteryLevelReceiver.java
+++ b/src/main/java/org/radarcns/android/util/BatteryLevelReceiver.java
@@ -25,7 +25,7 @@ import static android.os.BatteryManager.EXTRA_LEVEL;
 import static android.os.BatteryManager.EXTRA_PLUGGED;
 import static android.os.BatteryManager.EXTRA_SCALE;
 
-/** Keep track of battery level events */
+/** Keep track of battery level events. */
 public class BatteryLevelReceiver extends SpecificReceiver {
     private final BatteryLevelListener listener;
     private float level;
@@ -56,19 +56,28 @@ public class BatteryLevelReceiver extends SpecificReceiver {
         }
     }
 
+    /** Latest battery level in range [0, 1]. */
     public float getLevel() {
         return level;
     }
 
+    /** Latest value whether the device is plugged into a charger. */
     public boolean isPlugged() {
         return isPlugged;
     }
 
+    /** Returns true if the current battery level is at least the given level, or that the device is
+     * currently plugged in. Returns false otherwise. */
     public boolean hasMinimumLevel(float minLevel) {
         return level >= minLevel || isPlugged;
     }
 
     public interface BatteryLevelListener {
+        /**
+         * Latest battery level reported by the system.
+         * @param level battery level in range [0, 1]
+         * @param isPlugged whether the device is plugged into a charger
+         */
         void onBatteryLevelChanged(float level, boolean isPlugged);
     }
 }

--- a/src/main/java/org/radarcns/android/util/LocalSingleThreadExecutorFactory.java
+++ b/src/main/java/org/radarcns/android/util/LocalSingleThreadExecutorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SingleThreadExecutorFactory that creates a new single-threaded executor in getter invocation.
+ */
+public class LocalSingleThreadExecutorFactory implements SingleThreadExecutorFactory {
+    private final List<ExecutorService> services;
+    private final ThreadFactory threadFactory;
+
+    public LocalSingleThreadExecutorFactory(ThreadFactory threadFactory) {
+        this.threadFactory = threadFactory;
+        this.services = new ArrayList<>();
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduledExecutorService() {
+        ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        services.add(service);
+        return service;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        ExecutorService service = Executors.newSingleThreadExecutor(threadFactory);
+        services.add(service);
+        return service;
+    }
+
+    @Override
+    public boolean join(long timeout) throws InterruptedException {
+        long start = System.currentTimeMillis();
+        boolean didTerminate = true;
+        for (ExecutorService service : services) {
+            long alreadyWaited = System.currentTimeMillis() - start;
+            if (alreadyWaited > timeout) {
+                return false;
+            }
+            didTerminate = service.awaitTermination(timeout - alreadyWaited, TimeUnit.MILLISECONDS);
+        }
+        return didTerminate;
+    }
+
+    @Override
+    public void close() {
+        for (ExecutorService service : services) {
+            service.shutdown();
+        }
+    }
+}

--- a/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
+++ b/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
@@ -30,7 +30,7 @@ public class NetworkConnectedReceiver extends SpecificReceiver {
     public NetworkConnectedReceiver(@NonNull Context context, NetworkConnectedListener listener) {
         super(context);
         this.listener = listener;
-        this.isConnected = false;
+        this.isConnected = true;
     }
 
     @Override

--- a/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
+++ b/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import static android.net.ConnectivityManager.CONNECTIVITY_ACTION;
+import static android.net.ConnectivityManager.EXTRA_NO_CONNECTIVITY;
+
+public class NetworkConnectedReceiver extends SpecificReceiver {
+    private final NetworkConnectedListener listener;
+    private boolean isConnected;
+
+    public NetworkConnectedReceiver(@NonNull Context context, NetworkConnectedListener listener) {
+        super(context);
+        this.listener = listener;
+        this.isConnected = false;
+    }
+
+    @Override
+    protected void onSpecificReceive(Intent intent) {
+        this.isConnected = !intent.getBooleanExtra(EXTRA_NO_CONNECTIVITY, false);
+        if (listener != null) {
+            listener.onNetworkConnectionChanged(this.isConnected);
+        }
+    }
+
+    @Override
+    protected String getAction() {
+        return CONNECTIVITY_ACTION;
+    }
+
+    public boolean isConnected() {
+        return isConnected;
+    }
+
+    public interface NetworkConnectedListener {
+        void onNetworkConnectionChanged(boolean isConnected);
+    }
+}

--- a/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
+++ b/src/main/java/org/radarcns/android/util/NetworkConnectedReceiver.java
@@ -43,9 +43,14 @@ public class NetworkConnectedReceiver extends SpecificReceiver {
     protected void onSpecificReceive(Intent intent) {
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
-        isConnected = activeNetwork.isConnected();
-        hasWifiOrEthernet = activeNetwork.getType() == TYPE_WIFI
-                || activeNetwork.getType() == TYPE_ETHERNET;
+        if (activeNetwork == null) {
+            isConnected = false;
+            hasWifiOrEthernet = false;
+        } else {
+            isConnected = activeNetwork.isConnected();
+            int networkType = activeNetwork.getType();
+            hasWifiOrEthernet = networkType == TYPE_WIFI || networkType == TYPE_ETHERNET;
+        }
         if (listener != null) {
             listener.onNetworkConnectionChanged(isConnected, hasWifiOrEthernet);
         }

--- a/src/main/java/org/radarcns/android/util/PersistentStorage.java
+++ b/src/main/java/org/radarcns/android/util/PersistentStorage.java
@@ -36,6 +36,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * A class-bounded file-based storage to load or store properties.
+ * @deprecated Use SharedPreferences instead to avoid needing external files permissions.
+ */
+@Deprecated
 public class PersistentStorage {
     private static Logger logger = LoggerFactory.getLogger(PersistentStorage.class);
 

--- a/src/main/java/org/radarcns/android/util/SharedSingleThreadExecutorFactory.java
+++ b/src/main/java/org/radarcns/android/util/SharedSingleThreadExecutorFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * SingleThreadExecutorFactory that returns the same single-threaded executor in each getter
+ * invocation.
+ */
+public class SharedSingleThreadExecutorFactory implements SingleThreadExecutorFactory {
+    private final ScheduledExecutorService service;
+
+    public SharedSingleThreadExecutorFactory(ThreadFactory threadFactory) {
+        service = Executors.newSingleThreadScheduledExecutor(threadFactory);
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduledExecutorService() {
+        return service;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return service;
+    }
+
+    @Override
+    public boolean join(long timeout) throws InterruptedException {
+        return service.awaitTermination(timeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() {
+        service.shutdown();
+    }
+}

--- a/src/main/java/org/radarcns/android/util/SingleThreadExecutorFactory.java
+++ b/src/main/java/org/radarcns/android/util/SingleThreadExecutorFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import java.io.Closeable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+public interface SingleThreadExecutorFactory extends Closeable {
+    /**
+     * Create or get a cached single threaded scheduled executor. This executor may only be shutdown
+     * through {@link #close()} of this factory.
+     * @return scheduled executor service
+     */
+    ScheduledExecutorService getScheduledExecutorService();
+    /**
+     * Create or get a cached single threaded executor. This executor may only be shutdown
+     * through {@link #close()} of this factory.
+     * @return executor service
+     */
+    ExecutorService getExecutorService();
+
+    /**
+     * Await the termination of all created executors. Do not call before calling {@link #close()}.
+     * @param timeout number of milliseconds to wait.
+     * @return true if all executors terminated before the timeout, false otherwise.
+     * @throws InterruptedException if the join operation is interrupted.
+     */
+    boolean join(long timeout) throws InterruptedException;
+
+    /**
+     * Shutdown all created executors. Call this instead of closing the individually returned
+     * executors. This does not wait for the termination of the executors, so existing tasks will
+     * be run first. To wait for all existing tasks, call {@link #join(long)}.
+     */
+    @Override
+    void close();
+}

--- a/src/main/java/org/radarcns/android/util/SpecificReceiver.java
+++ b/src/main/java/org/radarcns/android/util/SpecificReceiver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.util;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.support.annotation.NonNull;
+
+import java.util.Objects;
+
+public abstract class SpecificReceiver extends BroadcastReceiver {
+    private final Context context;
+
+    public SpecificReceiver(@NonNull Context context) {
+        Objects.requireNonNull(context);
+        this.context = context;
+    }
+
+    protected abstract String getAction();
+    protected abstract void onSpecificReceive(Intent intent);
+
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || !intent.getAction().equals(getAction())) {
+            return;
+        }
+        onSpecificReceive(intent);
+    }
+
+    public void register() {
+        context.registerReceiver(this, new IntentFilter(getAction()));
+    }
+
+    public void unregister() {
+        context.unregisterReceiver(this);
+    }
+}

--- a/src/main/java/org/radarcns/android/util/SpecificReceiver.java
+++ b/src/main/java/org/radarcns/android/util/SpecificReceiver.java
@@ -43,7 +43,8 @@ public abstract class SpecificReceiver extends BroadcastReceiver {
     }
 
     public void register() {
-        context.registerReceiver(this, new IntentFilter(getAction()));
+        Intent init = context.registerReceiver(this, new IntentFilter(getAction()));
+        onReceive(context, init);
     }
 
     public void unregister() {

--- a/src/main/java/org/radarcns/android/util/SpecificReceiver.java
+++ b/src/main/java/org/radarcns/android/util/SpecificReceiver.java
@@ -25,7 +25,7 @@ import android.support.annotation.NonNull;
 import java.util.Objects;
 
 public abstract class SpecificReceiver extends BroadcastReceiver {
-    private final Context context;
+    protected final Context context;
 
     public SpecificReceiver(@NonNull Context context) {
         Objects.requireNonNull(context);

--- a/src/main/java/org/radarcns/util/BackedObjectQueue.java
+++ b/src/main/java/org/radarcns/util/BackedObjectQueue.java
@@ -16,9 +16,6 @@
 
 package org.radarcns.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,8 +31,6 @@ import java.util.NoSuchElementException;
  * @param <T> type of objects to store.
  */
 public class BackedObjectQueue<T> implements Closeable {
-    private static final Logger logger = LoggerFactory.getLogger(BackedObjectQueue.class);
-
     private final Converter<T> converter;
     private final QueueFile queueFile;
 

--- a/src/main/java/org/radarcns/util/QueueFileOutputStream.java
+++ b/src/main/java/org/radarcns/util/QueueFileOutputStream.java
@@ -130,16 +130,17 @@ public class QueueFileOutputStream extends OutputStream {
 
     /** Expands the storage if necessary, updating the queue length if needed. */
     private void expandAndUpdate(long length) throws IOException {
-        streamBytesUsed += length;
+        long newStreamBytesUsed = streamBytesUsed + length;
+        long bytesNeeded = queue.usedBytes() + newStreamBytesUsed;
 
-        long oldLength = header.getLength();
-
-        long bytesNeeded = usedSize();
-        if (bytesNeeded <= oldLength) {
-            return;
-        }
         if (bytesNeeded > queue.getMaximumFileSize()) {
             throw new IOException("Data does not fit in queue");
+        }
+
+        streamBytesUsed = newStreamBytesUsed;
+        long oldLength = header.getLength();
+        if (bytesNeeded <= oldLength) {
+            return;
         }
 
         logger.debug("Extending {}", queue);

--- a/src/main/res/xml/remote_config_defaults_template.xml
+++ b/src/main/res/xml/remote_config_defaults_template.xml
@@ -60,5 +60,9 @@
         <!-- 450 MB ~ 5.5 million records. With a 64 Hz stream, that fills up after 24 hours. -->
         <value>450000000</value>
     </entry>
+    <entry>
+        <key>send_only_with_wifi</key>
+        <value>true</value>
+    </entry>
 </defaultsMap>
 <!-- END xml_defaults -->

--- a/src/main/res/xml/remote_config_defaults_template.xml
+++ b/src/main/res/xml/remote_config_defaults_template.xml
@@ -54,5 +54,11 @@
         <key>kafka_upload_minimum_battery_level</key>
         <value>0.1</value>
     </entry>
+    <!-- Cache size per topic -->
+    <entry>
+        <key>max_cache_size_bytes</key>
+        <!-- 450 MB ~ 5.5 million records. With a 64 Hz stream, that fills up after 24 hours. -->
+        <value>450000000</value>
+    </entry>
 </defaultsMap>
 <!-- END xml_defaults -->

--- a/src/test/java/org/radarcns/android/data/TapeCacheTest.java
+++ b/src/test/java/org/radarcns/android/data/TapeCacheTest.java
@@ -30,6 +30,7 @@ import org.radarcns.key.MeasurementKey;
 import org.radarcns.topic.AvroTopic;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -39,6 +40,7 @@ import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class TapeCacheTest {
     private SharedSingleThreadExecutorFactory executorFactory;
     private TapeCache<MeasurementKey, ApplicationUptime> tapeCache;
@@ -92,6 +94,15 @@ public class TapeCacheTest {
         tapeCache.markSent(record.offset);
         assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
         assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+
+        tapeCache.addMeasurement(key, value);
+        tapeCache.addMeasurement(key, value);
+
+        Thread.sleep(100);
+
+        unsent = tapeCache.unsentRecords(100);
+        assertEquals(2, unsent.size());
+        assertEquals(new Pair<>(2L, 0L), tapeCache.numberOfRecords());
     }
 
 

--- a/src/test/java/org/radarcns/android/data/TapeCacheTest.java
+++ b/src/test/java/org/radarcns/android/data/TapeCacheTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarcns.android.data;
+
+import android.util.Pair;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.radarcns.android.util.AndroidThreadFactory;
+import org.radarcns.android.util.SharedSingleThreadExecutorFactory;
+import org.radarcns.application.ApplicationUptime;
+import org.radarcns.data.Record;
+import org.radarcns.key.MeasurementKey;
+import org.radarcns.topic.AvroTopic;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class TapeCacheTest {
+    private SharedSingleThreadExecutorFactory executorFactory;
+    private TapeCache<MeasurementKey, ApplicationUptime> tapeCache;
+    private MeasurementKey key;
+    private ApplicationUptime value;
+
+    @Before
+    public void setUp() throws IOException {
+        AvroTopic<MeasurementKey, ApplicationUptime> topic = new AvroTopic<>("test",
+                MeasurementKey.getClassSchema(), ApplicationUptime.getClassSchema(),
+                MeasurementKey.class, ApplicationUptime.class);
+        executorFactory = new SharedSingleThreadExecutorFactory(
+                new AndroidThreadFactory("test", THREAD_PRIORITY_BACKGROUND));
+        tapeCache = new TapeCache<>(
+                RuntimeEnvironment.application.getApplicationContext(),
+                topic, 100, executorFactory, 4096);
+
+        key = new MeasurementKey("a", "b");
+        double time = System.currentTimeMillis() / 1000d;
+        value = new ApplicationUptime(time, time, System.nanoTime() / 1_000_000_000d);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        tapeCache.close();
+        executorFactory.close();
+    }
+
+    @Test
+    public void addMeasurement() throws Exception {
+        assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
+        assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+        assertEquals(Collections.emptyList(), tapeCache.getRecords(100));
+
+        tapeCache.addMeasurement(key, value);
+
+        assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
+        assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+
+        Thread.sleep(100);
+
+        List<Record<MeasurementKey, ApplicationUptime>> unsent = tapeCache.unsentRecords(100);
+        assertEquals(1, unsent.size());
+        assertEquals(new Pair<>(1L, 0L), tapeCache.numberOfRecords());
+        unsent = tapeCache.unsentRecords(100);
+        assertEquals(1, unsent.size());
+        assertEquals(new Pair<>(1L, 0L), tapeCache.numberOfRecords());
+        Record<MeasurementKey, ApplicationUptime> record = unsent.get(0);
+        assertEquals(key, record.key);
+        assertEquals(value, record.value);
+        tapeCache.markSent(record.offset);
+        assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
+        assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+    }
+
+
+    @Test
+    public void flush() throws Exception {
+        assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
+        assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+        assertEquals(Collections.emptyList(), tapeCache.getRecords(100));
+
+        tapeCache.addMeasurement(key, value);
+
+        assertEquals(Collections.emptyList(), tapeCache.unsentRecords(100));
+        assertEquals(new Pair<>(0L, 0L), tapeCache.numberOfRecords());
+
+        tapeCache.flush();
+
+        assertEquals(1, tapeCache.unsentRecords(100).size());
+        assertEquals(new Pair<>(1L, 0L), tapeCache.numberOfRecords());
+    }
+}


### PR DESCRIPTION
It turned out there were some timers that took some time to time out, plus an unnoticed deadlock in TapeCache. Changes in this pull request:

- Updated target Android build to API 25 (Android 7.1) and the minimum API to API 21 (Android 5.0).
- Changed the way that MainActivity binds and unbinds to AsyncTask instead of using the UI update Handler.
- Initial update to handling multiple permissions from multiple DeviceServiceProvider.
- Deprecated PersistentStorage instead of RadarConfiguration
- Debugged and tested TapeCache synchronisation
- Made multithreading in TapeCache handled by a ScheduledExecutorService factory
- Added helper BroadcastReceivers for battery status and network connection status
- Update upload rate based on battery status with reduced messages at <0.2 (send 5 times fewer messages, except when a single message batch fills up) and no more messages with battery status <0.1.
