### PR TITLE
Propagate ManagementPortal source IDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,12 @@ allprojects {
 
     repositories {
         jcenter()
+        // radar dev branches
         maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local' }
     }
 
     dependencies {
         compile 'com.squareup.okhttp3:okhttp:3.8.0'
-
         compile 'com.google.firebase:firebase-config:11.0.4'
 
         compile('org.radarcns:radar-commons:0.6-SNAPSHOT') {

--- a/src/main/java/org/radarcns/android/MainActivity.java
+++ b/src/main/java/org/radarcns/android/MainActivity.java
@@ -190,8 +190,7 @@ public abstract class MainActivity extends Activity {
 
         authState = AppAuthState.Builder.from(this).build();
         if (!authState.isValid()) {
-            startActivity(new Intent(this, loginActivity()));
-            finish();
+            startLogin(false);
             return;
         }
         radarConfiguration.put(RadarConfiguration.PROJECT_ID_KEY, authState.getProjectId());
@@ -306,7 +305,7 @@ public abstract class MainActivity extends Activity {
         logger.info("mainActivity onStart");
         super.onStart();
         if (!authState.isValid()) {
-            startLogin();
+            startLogin(true);
         }
         registerReceiver(bluetoothReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
         registerReceiver(deviceFailedReceiver, new IntentFilter(DEVICE_CONNECT_FAILED));
@@ -635,14 +634,20 @@ public abstract class MainActivity extends Activity {
                 }
                 authState.invalidate(this);
             }
-            startLogin();
+            startLogin(true);
         }
     }
 
-    protected void startLogin() {
+    protected void startLogin(boolean forResult) {
         Intent intent = new Intent(this, loginActivity());
-        intent.setAction(ACTION_LOGIN);
-        startActivityForResult(intent, LOGIN_REQUEST_CODE);
+
+        if (forResult) {
+            intent.setAction(ACTION_LOGIN);
+            startActivityForResult(intent, LOGIN_REQUEST_CODE);
+        } else {
+            startActivity(intent);
+            finish();
+        }
     }
 
     public void updateServerRecordsSent(DeviceServiceConnection<?> connection, String topic,

--- a/src/main/java/org/radarcns/android/MainActivity.java
+++ b/src/main/java/org/radarcns/android/MainActivity.java
@@ -41,6 +41,7 @@ import android.widget.Toast;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import org.radarcns.android.auth.AppAuthState;
+import org.radarcns.android.auth.AppSource;
 import org.radarcns.android.auth.LoginActivity;
 import org.radarcns.android.device.DeviceServiceConnection;
 import org.radarcns.android.device.DeviceServiceProvider;
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -409,7 +411,15 @@ public abstract class MainActivity extends Activity {
             }
 
             logger.info("Starting recording on connection {}", connection);
-            connection.startRecording(deviceFilters.get(connection));
+            AppSource source = provider.getSource();
+            Set<String> filters;
+            if (source != null && source.getExpectedSourceName() != null) {
+                String[] expectedIds = source.getExpectedSourceName().split(",");
+                filters = new HashSet<>(Arrays.asList(expectedIds));
+            } else {
+                filters = deviceFilters.get(connection);
+            }
+            connection.startRecording(filters);
         }
     }
 

--- a/src/main/java/org/radarcns/android/RadarConfiguration.java
+++ b/src/main/java/org/radarcns/android/RadarConfiguration.java
@@ -49,7 +49,7 @@ public class RadarConfiguration {
 
     public static final String KAFKA_REST_PROXY_URL_KEY = "kafka_rest_proxy_url";
     public static final String SCHEMA_REGISTRY_URL_KEY = "schema_registry_url";
-    public static final String MANAGEMENT_PORTAL_URL = "management_portal_url";
+    public static final String MANAGEMENT_PORTAL_URL_KEY = "management_portal_url";
     public static final String PROJECT_ID_KEY = "project_id";
     public static final String USER_ID_KEY = "user_id";
     public static final String SOURCE_ID_KEY = "source_id";

--- a/src/main/java/org/radarcns/android/auth/AppAuthState.java
+++ b/src/main/java/org/radarcns/android/auth/AppAuthState.java
@@ -24,6 +24,7 @@ import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
+import okhttp3.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +113,15 @@ public final class AppAuthState {
     @NonNull
     public List<Map.Entry<String, String>> getHeaders() {
         return headers;
+    }
+
+    @NonNull
+    public Headers getOkHttpHeaders() {
+        Headers.Builder builder = new Headers.Builder();
+        for (Map.Entry<String, String> header : headers) {
+            builder.add(header.getKey(), header.getValue());
+        }
+        return builder.build();
     }
 
     public boolean isValid() {

--- a/src/main/java/org/radarcns/android/auth/AppSource.java
+++ b/src/main/java/org/radarcns/android/auth/AppSource.java
@@ -1,22 +1,57 @@
 package org.radarcns.android.auth;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
-public class AppSource implements Serializable {
+public class AppSource implements Parcelable, Serializable {
+    private final long deviceTypeId;
     private final String deviceProducer;
     private final String deviceModel;
     private final String catalogVersion;
     private final boolean dynamicRegistration;
     private String sourceId;
+    private String sourceName;
     private String expectedSourceName;
+    private Map<String, String> attributes;
 
-    public AppSource(String deviceProducer, String deviceModel, String catalogVersion,
+    public static final Creator<AppSource> CREATOR = new Creator<AppSource>() {
+        @Override
+        public AppSource createFromParcel(Parcel parcel) {
+            AppSource source = new AppSource(parcel.readLong(), parcel.readString(), parcel.readString(),
+                    parcel.readString(), parcel.readByte() == 1);
+            source.setSourceId(parcel.readString());
+            source.setSourceName(parcel.readString());
+            source.setExpectedSourceName(parcel.readString());
+            int len = parcel.readInt();
+            Map<String, String> attr = new HashMap<>(len * 4 / 3 + 1);
+            for (int i = 0; i < len; i++) {
+                attr.put(parcel.readString(), parcel.readString());
+            }
+            source.setAttributes(attr);
+            return source;
+        }
+
+        @Override
+        public AppSource[] newArray(int i) {
+            return new AppSource[i];
+        }
+    };
+
+    public AppSource(long deviceTypeId, String deviceProducer, String deviceModel, String catalogVersion,
             boolean dynamicRegistration) {
+        this.deviceTypeId = deviceTypeId;
         this.deviceProducer = deviceProducer;
         this.deviceModel = deviceModel;
         this.catalogVersion = catalogVersion;
         this.dynamicRegistration = dynamicRegistration;
+        this.attributes = new HashMap<>();
     }
 
     public String getDeviceProducer() {
@@ -51,6 +86,16 @@ public class AppSource implements Serializable {
         this.expectedSourceName = expectedSourceName;
     }
 
+    @NonNull
+    public Map<String, String> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    public void setAttributes(Map<? extends String, ? extends String> attributes) {
+        this.attributes.clear();
+        this.attributes.putAll(attributes);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -60,28 +105,69 @@ public class AppSource implements Serializable {
             return false;
         }
         AppSource appSource = (AppSource) o;
-        return dynamicRegistration == appSource.dynamicRegistration
+        return deviceTypeId == appSource.deviceTypeId
+                && dynamicRegistration == appSource.dynamicRegistration
                 && Objects.equals(deviceProducer, appSource.deviceProducer)
                 && Objects.equals(deviceModel, appSource.deviceModel)
                 && Objects.equals(catalogVersion, appSource.catalogVersion)
                 && Objects.equals(sourceId, appSource.sourceId)
-                && Objects.equals(expectedSourceName, appSource.expectedSourceName);
+                && Objects.equals(sourceName, appSource.sourceName)
+                && Objects.equals(expectedSourceName, appSource.expectedSourceName)
+                && Objects.equals(attributes, appSource.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(deviceProducer, deviceModel, catalogVersion, dynamicRegistration,
-                sourceId, expectedSourceName);
+        return Objects.hash(deviceTypeId, deviceProducer, deviceModel, catalogVersion,
+                dynamicRegistration, sourceId, sourceName, expectedSourceName, attributes);
     }
 
     @Override
     public String toString() {
-        return "AppSource{" + "deviceProducer='" + deviceProducer + '\''
+        return "AppSource{"
+                + "deviceTypeId='" + deviceTypeId + '\''
+                + ", deviceProducer='" + deviceProducer + '\''
                 + ", deviceModel='" + deviceModel + '\''
                 + ", catalogVersion='" + catalogVersion + '\''
                 + ", dynamicRegistration=" + dynamicRegistration
                 + ", sourceId='" + sourceId + '\''
+                + ", sourceName='" + sourceName + '\''
                 + ", expectedSourceName='" + expectedSourceName + '\''
+                + ", attributes=" + attributes + '\''
                 + '}';
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeLong(deviceTypeId);
+        parcel.writeString(deviceProducer);
+        parcel.writeString(deviceModel);
+        parcel.writeString(catalogVersion);
+        parcel.writeByte(dynamicRegistration ? (byte)1 : (byte)0);
+        parcel.writeString(sourceId);
+        parcel.writeString(sourceName);
+        parcel.writeString(expectedSourceName);
+        parcel.writeInt(attributes.size());
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            parcel.writeString(entry.getKey());
+            parcel.writeString(entry.getValue());
+        }
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+
+    public long getDeviceTypeId() {
+        return deviceTypeId;
     }
 }

--- a/src/main/java/org/radarcns/android/auth/LoginActivity.java
+++ b/src/main/java/org/radarcns/android/auth/LoginActivity.java
@@ -20,10 +20,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-
 import android.widget.Toast;
 import org.radarcns.android.R;
-import org.radarcns.android.RadarConfiguration;
 import org.radarcns.android.util.Boast;
 import org.radarcns.config.ServerConfig;
 import org.slf4j.Logger;
@@ -36,7 +34,6 @@ import java.util.Objects;
 
 import static org.radarcns.android.RadarConfiguration.MANAGEMENT_PORTAL_URL_KEY;
 import static org.radarcns.android.RadarConfiguration.RADAR_PREFIX;
-import static org.radarcns.android.auth.ManagementPortalClient.SOURCES_PROPERTY;
 
 /** Activity to log in using a variety of login managers. */
 public abstract class LoginActivity extends Activity implements LoginListener {
@@ -52,11 +49,11 @@ public abstract class LoginActivity extends Activity implements LoginListener {
     @Override
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
-        Intent intent = getIntent();
         if (savedInstanceBundle != null) {
             startedFromActivity = savedInstanceBundle.getBoolean(ACTION_LOGIN);
             managementPortalUrl = savedInstanceBundle.getString(MANAGEMENT_PORTAL_URL_KEY);
         } else {
+            Intent intent = getIntent();
             startedFromActivity = Objects.equals(intent.getAction(), ACTION_LOGIN);
             managementPortalUrl = intent.getStringExtra(RADAR_PREFIX + MANAGEMENT_PORTAL_URL_KEY);
         }
@@ -109,8 +106,8 @@ public abstract class LoginActivity extends Activity implements LoginListener {
     }
 
     /**
-     * Create your login managers here. Be sure to call the appropriate login manager's start()
-     * method if the user indicates that login method.
+     * Create your login managers here. Call {@link LoginManager#start()} for the login method that
+     * a user indicates.
      * @param appAuth previous invalid authentication
      * @return non-empty list of login managers to use
      */
@@ -127,14 +124,15 @@ public abstract class LoginActivity extends Activity implements LoginListener {
         }
     }
 
+    /** Call when part of the login procedure failed. */
     public void loginFailed(LoginManager manager, Exception ex) {
         logger.error("Failed to log in with {}", manager, ex);
         Boast.makeText(this, R.string.login_failed, Toast.LENGTH_LONG).show();
     }
 
+    /** Call when the entire login procedure succeeded. */
     public void loginSucceeded(LoginManager manager, @NonNull AppAuthState appAuthState) {
-        // MP info is not needed or is up to date
-        if (mpClient == null || this.appAuth.getProperties().containsKey(SOURCES_PROPERTY)) {
+        if (mpClient == null) {
             this.appAuth = appAuthState;
         } else {
             try {

--- a/src/main/java/org/radarcns/android/auth/LoginActivity.java
+++ b/src/main/java/org/radarcns/android/auth/LoginActivity.java
@@ -39,9 +39,11 @@ import static org.radarcns.android.RadarConfiguration.RADAR_PREFIX;
 public abstract class LoginActivity extends Activity implements LoginListener {
     private static final Logger logger = LoggerFactory.getLogger(LoginActivity.class);
     public static final String ACTION_LOGIN = "org.radarcns.auth.LoginActivity.login";
+    public static final String ACTION_REFRESH = "org.radarcns.auth.LoginActivity.refresh";
 
     private List<LoginManager> loginManagers;
     private boolean startedFromActivity;
+    private boolean refreshOnly;
     private AppAuthState appAuth;
     private String managementPortalUrl;
     private ManagementPortalClient mpClient;
@@ -50,11 +52,14 @@ public abstract class LoginActivity extends Activity implements LoginListener {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
         if (savedInstanceBundle != null) {
+            refreshOnly = savedInstanceBundle.getBoolean(ACTION_REFRESH);
             startedFromActivity = savedInstanceBundle.getBoolean(ACTION_LOGIN);
             managementPortalUrl = savedInstanceBundle.getString(MANAGEMENT_PORTAL_URL_KEY);
         } else {
             Intent intent = getIntent();
-            startedFromActivity = Objects.equals(intent.getAction(), ACTION_LOGIN);
+            String action = intent.getAction();
+            refreshOnly = Objects.equals(action, ACTION_REFRESH);
+            startedFromActivity = Objects.equals(action, ACTION_LOGIN);
             managementPortalUrl = intent.getStringExtra(RADAR_PREFIX + MANAGEMENT_PORTAL_URL_KEY);
         }
 
@@ -98,6 +103,7 @@ public abstract class LoginActivity extends Activity implements LoginListener {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(ACTION_REFRESH, refreshOnly);
         outState.putBoolean(ACTION_LOGIN, startedFromActivity);
         outState.putString(MANAGEMENT_PORTAL_URL_KEY, managementPortalUrl);
 
@@ -145,7 +151,7 @@ public abstract class LoginActivity extends Activity implements LoginListener {
         this.appAuth.addToPreferences(this);
         if (startedFromActivity) {
             setResult(RESULT_OK, this.appAuth.toIntent());
-        } else {
+        } else if (!refreshOnly) {
             Intent next = new Intent(this, nextActivity());
             startActivity(next);
         }

--- a/src/main/java/org/radarcns/android/auth/ManagementPortalClient.java
+++ b/src/main/java/org/radarcns/android/auth/ManagementPortalClient.java
@@ -1,24 +1,35 @@
 package org.radarcns.android.auth;
 
+import android.support.annotation.NonNull;
 import android.util.SparseArray;
+import okhttp3.MediaType;
 import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.radarcns.config.ServerConfig;
+import org.radarcns.producer.AuthenticationException;
 import org.radarcns.producer.rest.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 public class ManagementPortalClient implements Closeable {
     public static final String SOURCES_PROPERTY =
             ManagementPortalClient.class.getName() + ".sources";
     private static final Logger logger = LoggerFactory.getLogger(ManagementPortalClient.class);
+    private static final MediaType APPLICATION_JSON = MediaType
+            .parse("application/json; charset=utf-8");
 
     private final RestClient client;
 
@@ -27,11 +38,11 @@ public class ManagementPortalClient implements Closeable {
     }
 
     public AppAuthState getSubject(AppAuthState state) throws IOException {
-        Request.Builder builder = client.requestBuilder("api/subjects/" + state.getUserId());
-        for (Map.Entry<String, String> header : state.getHeaders()) {
-            builder.header(header.getKey(), header.getValue());
-        }
-        String bodyString = client.requestString(builder.build());
+        Request request = client.requestBuilder("api/subjects/" + state.getUserId())
+                .headers(state.getOkHttpHeaders())
+                .build();
+
+        String bodyString = client.requestString(request);
 
         try {
             JSONObject object = new JSONObject(bodyString);
@@ -51,6 +62,83 @@ public class ManagementPortalClient implements Closeable {
         }
     }
 
+    public AppSource registerSource(AppAuthState auth, AppSource source)
+            throws IOException, JSONException {
+        RequestBody body = RequestBody.create(APPLICATION_JSON,
+                sourceRegistrationBody(source).toString());
+
+        Request request = client.requestBuilder(
+                "api/subjects/" + auth.getUserId() + "/sources")
+                .post(body)
+                .headers(auth.getOkHttpHeaders())
+                .header("Content-Type", "application/json; charset=utf-8")
+                .build();
+
+        try (Response response = client.request(request)) {
+            ResponseBody responseBody = response.body();
+            if (response.code() == 409) {
+                throw new IOException("Device type is already registered with the ManagementPortal");
+            } else if (response.code() == 404) {
+                throw new IOException("User " + auth.getUserId() + " is no longer registered with the ManagementPortal.");
+            } else if (response.code() == 400) {
+                throw new IOException("Bad request to request credentials with the ManagementPortal.");
+            } else if (response.code() == 401) {
+                throw new AuthenticationException("Authentication failure with the ManagementPortal.");
+            } else if (!response.isSuccessful()) {
+                if (responseBody != null) {
+                    throw new IOException(
+                            "Cannot complete device registration with the ManagementPortal: "
+                                    + responseBody.string());
+                } else {
+                    throw new IOException("Cannot complete device registration with the ManagementPortal.");
+                }
+            } else if (responseBody == null) {
+                throw new IOException("Device registration with the ManagementPortal did not yield result.");
+            } else {
+                parseSourceRegistration(responseBody.string(), source);
+                return source;
+            }
+        }
+    }
+
+    static JSONObject sourceRegistrationBody(AppSource source) throws JSONException {
+        JSONObject requestBody = new JSONObject();
+        if (source.getSourceName() != null) {
+            requestBody.put("sourceName", source.getSourceName());
+        }
+        requestBody.put("deviceTypeId", source.getDeviceTypeId());
+        Map<String, String> sourceAttributes = source.getAttributes();
+        if (!sourceAttributes.isEmpty()) {
+            JSONObject attrs = new JSONObject();
+            for (Map.Entry<String, String> attr : sourceAttributes.entrySet()) {
+                attrs.put(attr.getKey(), attr.getValue());
+            }
+            requestBody.put("attributes", attrs);
+        }
+        return requestBody;
+    }
+
+    /**
+     * Parse the response of a subject/source registration.
+     * @param body registration response body
+     * @param source existing source to update with server information.
+     * @throws JSONException if the provided body is not valid JSON with the correct properties
+     */
+    static void parseSourceRegistration(@NonNull String body, @NonNull AppSource source)
+            throws JSONException {
+        JSONObject responseObject = new JSONObject(body);
+        source.setSourceId(responseObject.getString("sourceId"));
+        source.setSourceName(responseObject.getString("sourceName"));
+        source.setExpectedSourceName(responseObject.getString("expectedSourceName"));
+        source.setAttributes(attributesToMap(responseObject.optJSONObject("attributes")));
+    }
+
+    /**
+     * Parse the user ID from a subject response object.
+     * @param object response JSON object of a subject call
+     * @return user ID
+     * @throws JSONException if the given JSON object does not contain a login property
+     */
     static String parseUserId(JSONObject object) throws JSONException {
         return object.getString("login");
     }
@@ -62,12 +150,15 @@ public class ManagementPortalClient implements Closeable {
         SparseArray<AppSource> devices = new SparseArray<>(numDevices);
         for (int i = 0; i < numDevices; i++) {
             JSONObject deviceTypeObj = deviceTypesArr.getJSONObject(i);
+            int deviceTypeId = deviceTypeObj.getInt("id");
+
             AppSource device = new AppSource(
+                    deviceTypeId,
                     deviceTypeObj.getString("deviceProducer"),
                     deviceTypeObj.getString("deviceModel"),
                     deviceTypeObj.getString("catalogVersion"),
                     deviceTypeObj.getBoolean("canRegisterDynamically"));
-            devices.put(deviceTypeObj.getInt("id"), device);
+            devices.put(deviceTypeId, device);
         }
         return devices;
     }
@@ -89,6 +180,7 @@ public class ManagementPortalClient implements Closeable {
             devices.remove(id);
             device.setExpectedSourceName(sourceObj.optString("expectedSourceName"));
             device.setSourceId(sourceObj.getString("sourceId"));
+            device.setAttributes(attributesToMap(sourceObj.optJSONObject("attributes")));
             actualSources.add(device);
         }
 
@@ -100,6 +192,18 @@ public class ManagementPortalClient implements Closeable {
         }
 
         return actualSources;
+    }
+
+    private static Map<String, String> attributesToMap(JSONObject attrObj) throws JSONException {
+        if (attrObj == null) {
+            return null;
+        }
+        Map<String, String> attrs = new HashMap<>();
+        for (Iterator<String> it = attrObj.keys(); it.hasNext(); ) {
+            String key = it.next();
+            attrs.put(key, attrObj.getString(key));
+        }
+        return attrs;
     }
 
     static String parseProjectId(JSONObject project) throws JSONException {

--- a/src/main/java/org/radarcns/android/auth/ManagementPortalClient.java
+++ b/src/main/java/org/radarcns/android/auth/ManagementPortalClient.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,8 +27,10 @@ public class ManagementPortalClient implements Closeable {
     public static final String SOURCES_PROPERTY =
             ManagementPortalClient.class.getName() + ".sources";
     private static final Logger logger = LoggerFactory.getLogger(ManagementPortalClient.class);
-    private static final MediaType APPLICATION_JSON = MediaType
-            .parse("application/json; charset=utf-8");
+    private static final String APPLICATION_JSON = "application/json";
+    private static final String APPLICATION_JSON_UTF8 = APPLICATION_JSON + "; charset=utf-8";
+    private static final MediaType APPLICATION_JSON_MEDIA_TYPE = MediaType
+            .parse(APPLICATION_JSON_UTF8);
 
     private final RestClient client;
 
@@ -40,6 +41,7 @@ public class ManagementPortalClient implements Closeable {
     public AppAuthState getSubject(AppAuthState state) throws IOException {
         Request request = client.requestBuilder("api/subjects/" + state.getUserId())
                 .headers(state.getOkHttpHeaders())
+                .header("Accept", APPLICATION_JSON)
                 .build();
 
         String bodyString = client.requestString(request);
@@ -64,15 +66,15 @@ public class ManagementPortalClient implements Closeable {
 
     public AppSource registerSource(AppAuthState auth, AppSource source)
             throws IOException, JSONException {
-        RequestBody body = RequestBody.create(APPLICATION_JSON,
+        RequestBody body = RequestBody.create(APPLICATION_JSON_MEDIA_TYPE,
                 sourceRegistrationBody(source).toString());
 
         Request request = client.requestBuilder(
                 "api/subjects/" + auth.getUserId() + "/sources")
                 .post(body)
                 .headers(auth.getOkHttpHeaders())
-                .header("Content-Type", "application/json; charset=utf-8")
-                .header("Accept", "application/json")
+                .header("Content-Type", APPLICATION_JSON_UTF8)
+                .header("Accept", APPLICATION_JSON)
                 .build();
 
         try (Response response = client.request(request)) {

--- a/src/main/java/org/radarcns/android/auth/ManagementPortalService.java
+++ b/src/main/java/org/radarcns/android/auth/ManagementPortalService.java
@@ -1,0 +1,110 @@
+package org.radarcns.android.auth;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.ResultReceiver;
+import android.util.SparseArray;
+import org.json.JSONException;
+import org.radarcns.config.ServerConfig;
+import org.radarcns.producer.AuthenticationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Objects;
+
+import static org.radarcns.android.RadarConfiguration.MANAGEMENT_PORTAL_URL_KEY;
+import static org.radarcns.android.auth.ManagementPortalClient.SOURCES_PROPERTY;
+import static org.radarcns.android.device.DeviceServiceProvider.SOURCE_KEY;
+
+public class ManagementPortalService extends IntentService {
+    public static final String RESULT_RECEIVER_PROPERTY = ManagementPortalService.class.getName()
+            + ".resultReceiver";
+    public static final int MANAGEMENT_PORTAL_REGISTRATION = 1;
+
+    private static final Logger logger = LoggerFactory.getLogger(ManagementPortalService.class);
+    private ManagementPortalClient client;
+    private SparseArray<AppSource> sources;
+
+    public ManagementPortalService() {
+        super(ManagementPortalService.class.getName());
+        sources = new SparseArray<>();
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        AppSource source = intent.getParcelableExtra(SOURCE_KEY);
+
+        AppSource resultSource = sources.get((int)source.getDeviceTypeId());
+        AppAuthState authState = AppAuthState.Builder.from(intent.getExtras()).build();
+
+        if (resultSource == null) {
+            ensureClient(intent);
+            try {
+                resultSource = client.registerSource(authState, source);
+                sources.put((int) resultSource.getDeviceTypeId(), resultSource);
+                @SuppressWarnings("unchecked")
+                List<AppSource> existingSources = (List<AppSource>) authState.getProperties().get(SOURCES_PROPERTY);
+                if (existingSources != null) {
+                    boolean containsSource = false;
+                    for (AppSource existingSource : existingSources) {
+                        if (Objects.equals(existingSource.getSourceId(), resultSource.getSourceId())) {
+                            containsSource = true;
+                            break;
+                        }
+                    }
+                    if (!containsSource) {
+                        authState.invalidate(getApplicationContext());
+                    }
+                }
+            } catch (AuthenticationException ex) {
+                authState.invalidate(getApplicationContext());
+            } catch (IOException | JSONException ex) {
+                logger.error("Failed to register source {} of type {} {}",
+                        source.getSourceName(), source.getDeviceProducer(),
+                        source.getDeviceModel(), ex);
+            }
+        }
+
+        ResultReceiver receiver = intent.getParcelableExtra(RESULT_RECEIVER_PROPERTY);
+        Bundle result = new Bundle();
+        result.putParcelable(SOURCE_KEY, resultSource);
+        authState.addToBundle(result);
+        receiver.send(MANAGEMENT_PORTAL_REGISTRATION, result);
+    }
+
+    private void ensureClient(Intent intent) {
+        if (client == null) {
+            String url = intent.getStringExtra(MANAGEMENT_PORTAL_URL_KEY);
+            try {
+                ServerConfig portalConfig = new ServerConfig(url);
+                client = new ManagementPortalClient(portalConfig);
+            } catch (MalformedURLException ex) {
+                logger.error("Management portal URL {} is invalid", url, ex);
+            }
+        }
+    }
+
+    public static Intent createRequest(Context context, ServerConfig managementPortalUrl,
+            AppSource source, AppAuthState state, ResultReceiver receiver) {
+        Intent intent = new Intent(context, ManagementPortalService.class);
+        Bundle extras = new Bundle();
+        extras.putString(MANAGEMENT_PORTAL_URL_KEY, managementPortalUrl.getUrlString());
+        extras.putParcelable(SOURCE_KEY, source);
+        state.addToBundle(extras);
+        extras.putParcelable(RESULT_RECEIVER_PROPERTY, receiver);
+        intent.putExtras(extras);
+        return intent;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (client != null) {
+            client.close();
+        }
+    }
+}

--- a/src/main/java/org/radarcns/android/data/TableDataHandler.java
+++ b/src/main/java/org/radarcns/android/data/TableDataHandler.java
@@ -152,7 +152,7 @@ public class TableDataHandler implements DataHandler<ObservationKey, SpecificRec
                 .encoders(new SpecificRecordEncoder(false), new SpecificRecordEncoder(false))
                 .connectionTimeout(senderConnectionTimeout, TimeUnit.SECONDS)
                 .useCompression(useCompression)
-                .headers(authState.getHeaders())
+                .headers(authState.getOkHttpHeaders())
                 .build();
         this.submitter = new KafkaDataSubmitter<>(this, sender, kafkaRecordsSendLimit,
                 getPreferredUploadRate(), authState.getUserId());

--- a/src/main/java/org/radarcns/android/device/DeviceManager.java
+++ b/src/main/java/org/radarcns/android/device/DeviceManager.java
@@ -17,6 +17,7 @@
 package org.radarcns.android.device;
 
 import android.support.annotation.NonNull;
+import org.radarcns.android.auth.AppSource;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -54,4 +55,10 @@ public interface DeviceManager<T> extends Closeable {
      * Get the name of a connected wearable device.
      */
     String getName();
+
+    /**
+     * Called when a source registration succeeds.
+     * @param source source metadata
+     */
+    void didRegister(AppSource source);
 }

--- a/src/main/java/org/radarcns/android/device/DeviceService.java
+++ b/src/main/java/org/radarcns/android/device/DeviceService.java
@@ -33,6 +33,8 @@ import org.radarcns.android.R;
 import org.radarcns.android.RadarApplication;
 import org.radarcns.android.RadarConfiguration;
 import org.radarcns.android.auth.AppAuthState;
+import org.radarcns.android.auth.AppSource;
+import org.radarcns.android.auth.ManagementPortalService;
 import org.radarcns.android.data.DataCache;
 import org.radarcns.android.data.TableDataHandler;
 import org.radarcns.android.kafka.ServerStatusListener;
@@ -51,6 +53,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.radarcns.android.RadarConfiguration.*;
 import static org.radarcns.android.device.DeviceServiceProvider.NEEDS_BLUETOOTH_KEY;
+import static org.radarcns.android.device.DeviceServiceProvider.SOURCE_KEY;
 
 /**
  * A service that manages a DeviceManager and a TableDataHandler to send addToPreferences the data of a
@@ -122,6 +125,9 @@ public abstract class DeviceService<T extends BaseDeviceState> extends Service i
     private boolean isConnected;
     private int latestStartId = -1;
     private boolean needsBluetooth;
+    private AppSource source;
+    private ServerConfig managementPortal;
+    private AppAuthState authState;
 
     @CallSuper
     @Override
@@ -516,7 +522,7 @@ public abstract class DeviceService<T extends BaseDeviceState> extends Service i
         boolean sendOnlyWithWifi = RadarConfiguration.getBooleanExtra(
                 bundle, SEND_ONLY_WITH_WIFI, true);
 
-        AppAuthState authState = AppAuthState.Builder.from(bundle).build();
+        authState = AppAuthState.Builder.from(bundle).build();
         int maxBytes = RadarConfiguration.getIntExtra(
                 bundle, MAX_CACHE_SIZE, Integer.MAX_VALUE);
 
@@ -583,6 +589,19 @@ public abstract class DeviceService<T extends BaseDeviceState> extends Service i
             localDataHandler.setMinimumBatteryLevel(RadarConfiguration.getFloatExtra(bundle,
                     KAFKA_UPLOAD_MINIMUM_BATTERY_LEVEL));
         }
+        source = bundle.getParcelable(SOURCE_KEY);
+        if (source.getSourceId() != null) {
+            key.setSourceId(source.getSourceId());
+        }
+        String managementPortalString = bundle.getString(RADAR_PREFIX + MANAGEMENT_PORTAL_URL_KEY, null);
+        if (managementPortalString != null) {
+            try {
+                managementPortal = new ServerConfig(managementPortalString);
+            } catch (MalformedURLException ex) {
+                logger.error("ManagementPortal url {} is invalid", managementPortalString, ex);
+            }
+        }
+
         boolean willNeedBluetooth = bundle.getBoolean(NEEDS_BLUETOOTH_KEY, false);
         if (!willNeedBluetooth && needsBluetooth) {
             unregisterReceiver(mBluetoothReceiver);
@@ -618,6 +637,52 @@ public abstract class DeviceService<T extends BaseDeviceState> extends Service i
 
     public ObservationKey getKey() {
         return key;
+    }
+
+    public AppSource getSource() {
+        return source;
+    }
+
+    public void registerDevice(String name, Map<String, String> attributes) {
+        if (source == null || source.getSourceId() != null) {
+            return;
+        }
+        source.setSourceName(name);
+        source.setAttributes(attributes);
+        if (managementPortal != null) {
+            Intent intent = ManagementPortalService.createRequest(this, managementPortal,
+                    source, authState, new ResultReceiver(new Handler(getMainLooper())) {
+                @Override
+                protected void onReceiveResult(int resultCode, Bundle result) {
+                    AppSource updatedSource = result.getParcelable(SOURCE_KEY);
+                    if (updatedSource == null) {
+                        // TODO: more error handling?
+                        logger.error("Failed to register source {}", source);
+                        stopDeviceManager(unsetDeviceManager());
+                        return;
+                    }
+                    AppAuthState auth = AppAuthState.Builder.from(result).build();
+                    if (auth.isInvalidated()) {
+                        logger.info("New source ID requires new OAuth2 JWT token.");
+                        updateServerStatus(ServerStatusListener.Status.UNAUTHORIZED);
+                    }
+                    key.setProjectId(auth.getProjectId());
+                    key.setUserId(auth.getUserId());
+                    key.setSourceId(updatedSource.getSourceId());
+                    source.setSourceId(updatedSource.getSourceId());
+                    source.setSourceName(updatedSource.getSourceName());
+                    source.setExpectedSourceName(updatedSource.getExpectedSourceName());
+                    DeviceManager<T> localManager = getDeviceManager();
+                    if (localManager != null) {
+                        localManager.didRegister(source);
+                    }
+                }
+            });
+            startService(intent);
+        } else {
+            source.setSourceId(RadarConfiguration.getOrSetUUID(this, SOURCE_ID_KEY));
+            getDeviceManager().didRegister(source);
+        }
     }
 
     @Override

--- a/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
+++ b/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
@@ -86,6 +86,23 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
     public abstract String getDisplayName();
 
     /**
+     * Image to display when onboarding for this service.
+     * @return resource number or -1 if none is available.
+     */
+    public int getDescriptionImage() {
+        return -1;
+    }
+
+    /**
+     * Description of the service. This should tell what the service does and why certain
+     * permissions are needed.
+     * @return description or {@code null} if no description is needed.
+     */
+    public String getDescription() {
+        return null;
+    }
+
+    /**
      * Whether the service has a UI detail view that can be invoked. If not,
      * {@link #showDetailView()} will throw an UnsupportedOperationException.
      */
@@ -204,7 +221,7 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
                 SENDER_CONNECTION_TIMEOUT_KEY, MAX_CACHE_SIZE, SEND_ONLY_WITH_WIFI,
                 SEND_WITH_COMPRESSION, UNSAFE_KAFKA_CONNECTION);
         String mpUrl = config.getString(MANAGEMENT_PORTAL_URL_KEY, null);
-        if (mpUrl != null) {
+        if (mpUrl != null && !mpUrl.isEmpty()) {
             config.put(RADAR_PREFIX + MANAGEMENT_PORTAL_URL_KEY, mpUrl);
         }
         ((RadarApplication)activity.getApplicationContext()).configureProvider(config, bundle);

--- a/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
+++ b/src/main/java/org/radarcns/android/device/DeviceServiceProvider.java
@@ -26,6 +26,7 @@ import android.support.annotation.NonNull;
 import org.radarcns.android.MainActivity;
 import org.radarcns.android.RadarApplication;
 import org.radarcns.android.RadarConfiguration;
+import org.radarcns.android.auth.AppSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,9 @@ import java.util.Scanner;
 
 import static android.Manifest.permission.BLUETOOTH;
 import static android.Manifest.permission.BLUETOOTH_ADMIN;
+import static org.radarcns.android.RadarConfiguration.MANAGEMENT_PORTAL_URL_KEY;
 import static org.radarcns.android.RadarConfiguration.PROJECT_ID_KEY;
+import static org.radarcns.android.RadarConfiguration.RADAR_PREFIX;
 import static org.radarcns.android.RadarConfiguration.USER_ID_KEY;
 import static org.radarcns.android.RadarConfiguration.KAFKA_CLEAN_RATE_KEY;
 import static org.radarcns.android.RadarConfiguration.KAFKA_RECORDS_SEND_LIMIT_KEY;
@@ -57,11 +60,13 @@ import static org.radarcns.android.RadarConfiguration.UNSAFE_KAFKA_CONNECTION;
 public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
     public static final String NEEDS_BLUETOOTH_KEY = DeviceServiceProvider.class.getName() + ".needsBluetooth";
     private static final Logger logger = LoggerFactory.getLogger(DeviceServiceProvider.class);
+    public static final String SOURCE_KEY = DeviceServiceProvider.class.getName() + ".source";
 
     private MainActivity activity;
     private RadarConfiguration config;
     private DeviceServiceConnection<T> connection;
     private boolean bound;
+    private AppSource source;
 
     /**
      * Class of the service.
@@ -198,11 +203,16 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
                 KAFKA_UPLOAD_RATE_KEY, KAFKA_CLEAN_RATE_KEY, KAFKA_RECORDS_SEND_LIMIT_KEY,
                 SENDER_CONNECTION_TIMEOUT_KEY, MAX_CACHE_SIZE, SEND_ONLY_WITH_WIFI,
                 SEND_WITH_COMPRESSION, UNSAFE_KAFKA_CONNECTION);
+        String mpUrl = config.getString(MANAGEMENT_PORTAL_URL_KEY, null);
+        if (mpUrl != null) {
+            config.put(RADAR_PREFIX + MANAGEMENT_PORTAL_URL_KEY, mpUrl);
+        }
         ((RadarApplication)activity.getApplicationContext()).configureProvider(config, bundle);
         List<String> permissions = needsPermissions();
         bundle.putBoolean(NEEDS_BLUETOOTH_KEY, permissions.contains(BLUETOOTH) ||
                 permissions.contains(BLUETOOTH_ADMIN));
         activity.getAuthState().addToBundle(bundle);
+        bundle.putParcelable(SOURCE_KEY, source);
     }
 
     /**
@@ -319,14 +329,19 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
     /**
      * Match device type.
      *
-     * @param deviceProducer producer of given device
-     * @param deviceModel model of given device
-     * @param version version of the device plugin API
+     * @param source stored source
+     * @param checkVersion whether to do a strict version check
      */
-    public boolean matches(@NonNull String deviceProducer, @NonNull String deviceModel,
-            String version) {
-        return deviceProducer.equals(getDeviceProducer()) && deviceModel.equals(getDeviceModel())
-                && version == null || version.equals(getVersion());
+    public boolean matches(AppSource source, boolean checkVersion) {
+        return source.getDeviceProducer().equals(getDeviceProducer())
+                && source.getDeviceModel().equals(getDeviceModel())
+                && !checkVersion
+                || source.getCatalogVersion() == null
+                || source.getCatalogVersion().equals(getVersion());
+    }
+
+    public void setSource(AppSource source) {
+        this.source = source;
     }
 
     @NonNull
@@ -337,4 +352,8 @@ public abstract class DeviceServiceProvider<T extends BaseDeviceState> {
 
     @NonNull
     public abstract String getVersion();
+
+    public AppSource getSource() {
+        return source;
+    }
 }


### PR DESCRIPTION
A logic branch is added when the management portal URL is specified:
- at login, the subject API is queried by the app in question
- only device service producers with the correct source metadata are started
- when a device manager starts, it tries to register the current source.
  - If it is already registered, the device manager gets the current information
  - otherwise, the app registers it with the management portal and tries to retrieve a new JWT access token. If this fails, a re-login-attempt is made.
- at any time that a login succeeds, the subject data is also updated.