### PR TITLE
use passed AppAuthState if local one is invalid

### DIFF
--- a/src/main/java/org/radarcns/android/auth/LoginActivity.java
+++ b/src/main/java/org/radarcns/android/auth/LoginActivity.java
@@ -133,6 +133,10 @@ public abstract class LoginActivity extends Activity implements LoginListener {
     /** Call when the entire login procedure succeeded. */
     public void loginSucceeded(LoginManager manager, @NonNull AppAuthState appAuthState) {
         logger.info("Login succeeded");
+
+        if (!this.appAuth.isValid() && appAuthState.isValid()) {
+            this.appAuth = appAuthState;
+        }
         this.appAuth.addToPreferences(this);
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(appAuth.toIntent().setAction(ACTION_LOGIN_SUCCESS));

--- a/src/main/java/org/radarcns/android/auth/LoginActivity.java
+++ b/src/main/java/org/radarcns/android/auth/LoginActivity.java
@@ -134,7 +134,7 @@ public abstract class LoginActivity extends Activity implements LoginListener {
     public void loginSucceeded(LoginManager manager, @NonNull AppAuthState appAuthState) {
         logger.info("Login succeeded");
 
-        if (!this.appAuth.isValid() && appAuthState.isValid()) {
+        if (appAuthState.isValid()) {
             this.appAuth = appAuthState;
         }
         this.appAuth.addToPreferences(this);

--- a/src/main/java/org/radarcns/android/device/DeviceService.java
+++ b/src/main/java/org/radarcns/android/device/DeviceService.java
@@ -84,7 +84,7 @@ public abstract class DeviceService<T extends BaseDeviceState> extends Service i
     public static final String CACHE_RECORDS_SENT_NUMBER = PREFIX + "DataCache.numberOfRecords.second";
     public static final String DEVICE_SERVICE_CLASS = PREFIX + "DeviceService.getClass";
     public static final String DEVICE_STATUS_CHANGED = PREFIX + "DeviceStatusListener.Status";
-    public static final String DEVICE_STATUS_NAME = PREFIX + "Devicemanager.getName";
+    public static final String DEVICE_STATUS_NAME = PREFIX + "DeviceManager.getName";
     public static final String DEVICE_CONNECT_FAILED = PREFIX + "DeviceStatusListener.deviceFailedToConnect";
     private final ObservationKey key = new ObservationKey();
 


### PR DESCRIPTION
This will make login without QR-Code/MP possible, like e.g. [here](https://github.com/RADAR-CNS/radar-prmt-android/blob/trivial_login/app/src/main/java/org/radarcns/detail/RadarLoginActivity.java#L124).

(also fixed a typo)