### PR TITLE
Utlizing OAuth2LoginManager for new pRMT flow (Second Step)

### DIFF
--- a/plugins/radar-android-login-oauth2/build.gradle
+++ b/plugins/radar-android-login-oauth2/build.gradle
@@ -2,7 +2,7 @@ apply from: "$rootDir/gradle/android.gradle"
 
 android {
     namespace "org.radarbase.android.auth.oauth2"
-    defaultConfig.manifestPlaceholders = ["appAuthRedirectScheme": "org.radarbase.android"]
+    defaultConfig.manifestPlaceholders = ["appAuthRedirectScheme": "https"]
 }
 
 description = "RADAR Android OAuth2 LoginManager."

--- a/plugins/radar-android-login-oauth2/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-login-oauth2/src/main/AndroidManifest.xml
@@ -1,1 +1,29 @@
-<manifest/>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+
+        <activity android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            tools:node="replace">
+
+            <intent-filter
+                android:label="@string/callback_redirect_response"
+                android:autoVerify="true"
+                >
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="https"
+                    android:host="radar-base.org"
+                    android:path="/prmt/oauth/callback"/>
+            </intent-filter>
+
+        </activity>
+
+    </application>
+
+</manifest>

--- a/plugins/radar-android-login-oauth2/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-login-oauth2/src/main/AndroidManifest.xml
@@ -21,6 +21,18 @@
                     android:host="radar-base.org"
                     android:path="/prmt/oauth/callback"/>
             </intent-filter>
+            <intent-filter
+                android:label="@string/custom_redirect_response"
+                android:autoVerify="true"
+                >
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="org.radarbase.prmt"
+                    android:host="radar-base.org"
+                    android:path="/prmt/oauth/callback"/>
+            </intent-filter>
 
         </activity>
 

--- a/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/OAuth2LoginManager.kt
+++ b/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/OAuth2LoginManager.kt
@@ -362,7 +362,7 @@ class OAuth2LoginManager(private val service: AuthService, appAuthState: AppAuth
             }
     }
 
-    override fun loginFailed(manager: LoginManager?, ex: Exception?) = this.service.loginFailed(this, ex)
+    override fun loginFailed(manager: LoginManager?, ex: Exception?) = Unit
 
     companion object {
         const val OAUTH2_SOURCE_TYPE = "org.radarcns.android.auth.oauth2.OAuth2LoginManager"

--- a/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/utils/client/OAuthClient.kt
+++ b/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/utils/client/OAuthClient.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.radarbase.android.auth.oauth2.utils.client
 
 import okhttp3.MediaType.Companion.toMediaType

--- a/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/utils/parser/PreLoginQrParser.kt
+++ b/plugins/radar-android-login-oauth2/src/main/java/org/radarbase/android/auth/oauth2/utils/parser/PreLoginQrParser.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.radarbase.android.auth.oauth2.utils.parser
 
 import org.json.JSONException

--- a/plugins/radar-android-login-oauth2/src/main/res/values/strings.xml
+++ b/plugins/radar-android-login-oauth2/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="callback_redirect_response">Open pRMT Callback Activity</string>
+    <string name="callback_redirect_response">Open pRMT Callback</string>
+    <string name="custom_redirect_response">Open pRMT App</string>
 </resources>

--- a/plugins/radar-android-login-oauth2/src/main/res/values/strings.xml
+++ b/plugins/radar-android-login-oauth2/src/main/res/values/strings.xml
@@ -1,2 +1,3 @@
 <resources>
+    <string name="callback_redirect_response">Open pRMT Callback Activity</string>
 </resources>


### PR DESCRIPTION

Added redirect links for `net.openid.appauth.RedirectUriReceiverActivity`

depends on: https://github.com/RADAR-base/radar-commons-android/pull/462

supports: https://github.com/RADAR-base/hydra-kratos/issues/52