### PR TITLE
Fixed sending of incorrect sourceIds to the gateway.

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
@@ -20,6 +20,7 @@ import android.os.IBinder
 import org.apache.avro.specific.SpecificRecord
 import org.radarbase.android.data.DataHandler
 import org.radarbase.android.kafka.ServerStatusListener
+import org.radarbase.android.source.PluginMetadataStore
 import org.radarbase.android.source.SourceProvider
 import org.radarbase.android.source.SourceServiceConnection
 import org.radarbase.android.util.TimedLong
@@ -33,6 +34,8 @@ interface IRadarBinder : IBinder {
     val connections: List<SourceProvider<*>>
 
     val dataHandler: DataHandler<ObservationKey, SpecificRecord>?
+
+    val pluginMetadataStore: PluginMetadataStore
 
     fun setAllowedSourceIds(connection: SourceServiceConnection<*>, allowedIds: Collection<String>)
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -74,6 +74,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
     var dataHandler: DataHandler<ObservationKey, SpecificRecord>? = null
         private set
 
+    val pluginMetadata = PluginMetadataStore()
+
     open val cacheStore: CacheStore = CacheStore()
 
     private lateinit var mHandler: SafeHandler
@@ -717,6 +719,9 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
                 }
             }
         }
+
+        override val pluginMetadataStore: PluginMetadataStore
+            get() = this@RadarService.pluginMetadata
 
         override val dataHandler: DataHandler<ObservationKey, SpecificRecord>?
             get() = this@RadarService.dataHandler

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -659,6 +659,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             }
             submitter {
                 userId = authState.userId
+                projectId = authState.projectId
             }
         }
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/data/TableDataHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/data/TableDataHandler.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.os.Process.THREAD_PRIORITY_BACKGROUND
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.apache.avro.specific.SpecificRecord
+import org.radarbase.android.RadarService
 import org.radarbase.android.kafka.KafkaDataSubmitter
 import org.radarbase.android.kafka.ServerStatusListener
 import org.radarbase.android.source.SourceService.Companion.CACHE_RECORDS_UNSENT_NUMBER
@@ -183,7 +184,7 @@ class TableDataHandler(
             sender = it
         }
 
-        this.submitter = KafkaDataSubmitter(this, sender, config.submitterConfig)
+        this.submitter = KafkaDataSubmitter(this, sender, config.submitterConfig, context as? RadarService)
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/kafka/KafkaDataSubmitter.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/kafka/KafkaDataSubmitter.kt
@@ -17,14 +17,20 @@
 package org.radarbase.android.kafka
 
 import android.os.Process
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
 import org.apache.avro.Schema
 import org.apache.avro.SchemaValidationException
 import org.apache.avro.generic.IndexedRecord
+import org.radarbase.android.RadarService
 import org.radarbase.android.data.DataCacheGroup
 import org.radarbase.android.data.DataHandler
 import org.radarbase.android.data.ReadableDataCache
+import org.radarbase.android.source.PluginMetadataStore
+import org.radarbase.android.util.MismatchedIdException
 import org.radarbase.android.util.SafeHandler
 import org.radarbase.data.AvroRecordData
+import org.radarbase.data.RecordData
 import org.radarbase.producer.AuthenticationException
 import org.radarbase.producer.KafkaSender
 import org.radarbase.producer.KafkaTopicSender
@@ -46,11 +52,14 @@ class KafkaDataSubmitter(
     private val dataHandler: DataHandler<*, *>,
     private val sender: KafkaSender,
     config: SubmitterConfiguration,
+    radarService: RadarService? = null,
 ) : Closeable {
 
     private val submitHandler = SafeHandler.getInstance("KafkaDataSubmitter", Process.THREAD_PRIORITY_BACKGROUND)
     private val topicSenders: MutableMap<String, KafkaTopicSender<Any, Any>> = HashMap()
     private val connection: KafkaConnectionChecker
+    private val pluginMetadata: PluginMetadataStore? = radarService?.pluginMetadata
+    private val reportedTopics: MutableSet<String> = mutableSetOf()
 
     var config: SubmitterConfiguration = config
         set(newValue) {
@@ -256,6 +265,42 @@ class KafkaDataSubmitter(
                     dataHandler.updateServerStatus(ServerStatusListener.Status.UPLOADING)
                 }
 
+                val keySourceId = retrieveDataFromFields(topic, data, "sourceId")
+                if (pluginMetadata != null) {
+                    val stringSourceId =  keySourceId as? String
+                    if (stringSourceId != null &&  stringSourceId !in pluginMetadata.sourceIds) {
+                        logger.warn("(MismatchedIdDebug) SourceId: {} for topic: {} doesn't match with any sourceId's. Discarding the data", stringSourceId, topic.name)
+                        dataHandler.let {
+                            it.updateRecordsSent(topic.name, size.toLong())
+                            // The upload has not actually failed yet, but if it proceeds, it will fail due to an incorrect sourceId.
+                            // Therefore, the status is explicitly set to UPLOADING_FAILED.
+                            it.updateServerStatus(ServerStatusListener.Status.UPLOADING_FAILED)
+                        }
+
+                        cache.remove(size)
+
+                        if (!reportedTopics.contains(topic.name)) {
+                            val pluginName = pluginMetadata.topicToPluginMapper.get(topic.name)
+                            val sourceId = pluginMetadata.pluginToSourceIdMapper[pluginName]
+                            val userId = retrieveDataFromFields(topic, data, "userId")
+                            val projectId = retrieveDataFromFields(topic, data, "projectId")
+
+                            nonFatalReportToCrashlytics(
+                                projectId,
+                                keySourceId,
+                                userId,
+                                topic.name,
+                                pluginName,
+                                sourceId
+                            )
+                            reportedTopics.add(topic.name)
+                        }
+                        return size
+                    }
+                } else {
+                    logger.warn("(MismatchedIdDebug) SourceId: {} for topic: {} matches.", keySourceId, topic.name)
+                }
+
                 try {
                     sender(topic).run {
                         send(AvroRecordData<Any, Any>(data.topic, data.key, recordsNotNull))
@@ -279,6 +324,26 @@ class KafkaDataSubmitter(
 
         return size
     }
+
+    private fun nonFatalReportToCrashlytics(
+        projectId: String?,
+        keySourceId: String?,
+        userId: String?,
+        topic: String,
+        pluginName: String?,
+        tokenSourceId: String?
+    ) {
+        Firebase.crashlytics.log("Mismatch detected in source ID for Plugin: $pluginName and Topic: $topic for User: $userId in Project: $projectId.")
+        userId?.let(Firebase.crashlytics::setUserId)
+        Firebase.crashlytics.recordException(MismatchedIdException("Mismatch detected in source ID for Plugin: $pluginName and Topic: $topic for User: $userId in Project: $projectId. The source ID in the payload ($keySourceId) does not match the source ID in the token ($tokenSourceId)."))
+    }
+
+    private fun retrieveDataFromFields(topic: AvroTopic<Any, Any>, data: RecordData<Any, Any?>, field: String) =
+        if (topic.keySchema.type == Schema.Type.RECORD) {
+            topic.keySchema.getField(field)?.let { fieldName ->
+                (data.key as IndexedRecord).get(fieldName.pos()).toString()
+            }
+        } else null
 
     companion object {
         private val logger = LoggerFactory.getLogger(KafkaDataSubmitter::class.java)

--- a/radar-commons-android/src/main/java/org/radarbase/android/kafka/SubmitterConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/kafka/SubmitterConfiguration.kt
@@ -5,6 +5,7 @@ import org.radarbase.android.config.SingleRadarConfiguration
 
 data class SubmitterConfiguration(
         var userId: String? = null,
+        var projectId: String? = null,
         var amountLimit: Int = 1000,
         var sizeLimit: Long = 5000000L,
         var uploadRate: Long = 10L,

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/AbstractSourceManager.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/AbstractSourceManager.kt
@@ -133,6 +133,7 @@ abstract class AbstractSourceManager<S : SourceService<T>, T : BaseSourceState>(
                 ObservationKey::class.java,
                 valueClass::class.java,
             )
+            addTopicMapping(name)
             return dataHandler.registerCache(topic, handler)
         } catch (e: ReflectiveOperationException) {
             logger.error("Error creating topic {}", name, e)
@@ -141,6 +142,10 @@ abstract class AbstractSourceManager<S : SourceService<T>, T : BaseSourceState>(
             logger.error("Error creating topic {}", name, e)
             throw RuntimeException(e)
         }
+    }
+
+    private fun addTopicMapping(topicName: String) {
+        service.mapTopicAndSource(topicName)
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/PluginMetadataStore.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/PluginMetadataStore.kt
@@ -1,0 +1,9 @@
+package org.radarbase.android.source
+
+import java.util.concurrent.ConcurrentHashMap
+
+data class PluginMetadataStore  (
+    val sourceIds: MutableSet<String> = mutableSetOf(),
+    val pluginToSourceIdMapper: MutableMap<String, String> = ConcurrentHashMap(20, 0.75f),
+    val topicToPluginMapper: MutableMap<String, String> = ConcurrentHashMap(30, 0.75f)
+)

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceService.kt
@@ -356,14 +356,14 @@ abstract class SourceService<T : BaseSourceState> : LifecycleService(), SourceSt
             pluginToSourceIdMapper[pluginName] = acceptableSources.joinToString(separator = " ") {
                 it.sourceId.toString()
             }
-        } ?: logger.warn("(MismatchedIdDebug) plugin metadata instance is null when adding plugin $this")
+        }
     }
 
     fun mapTopicAndSource(topicName: String) {
         metadataStore?.topicToPluginMapper?.putIfAbsent(
             topicName,
             pluginName
-        ) ?: logger.warn("(MismatchedIdDebug) plugin metadata instance is null when adding topic $this")
+        )
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceService.kt
@@ -60,6 +60,11 @@ abstract class SourceService<T : BaseSourceState> : LifecycleService(), SourceSt
     @get:Synchronized
     @set:Synchronized
     var dataHandler: DataHandler<ObservationKey, SpecificRecord>? = null
+
+    @get:Synchronized
+    @set:Synchronized
+    var metadataStore: PluginMetadataStore? = null
+
     @get:Synchronized
     var sourceManager: SourceManager<T>? = null
         private set
@@ -130,6 +135,7 @@ abstract class SourceService<T : BaseSourceState> : LifecycleService(), SourceSt
         radarConnection = ManagedServiceConnection(this, radarApp.radarService)
         radarConnection.onBoundListeners.add { binder ->
             dataHandler = binder.dataHandler
+            metadataStore = binder.pluginMetadataStore
             handler.execute {
                 startFuture?.runNow()
             }
@@ -340,6 +346,26 @@ abstract class SourceService<T : BaseSourceState> : LifecycleService(), SourceSt
 
     }
 
+    private fun addPluginMetadata() {
+        metadataStore?.apply {
+            acceptableSources.mapNotNull {
+                it.sourceId
+            }.forEach(sourceIds::add)
+
+
+            pluginToSourceIdMapper[pluginName] = acceptableSources.joinToString(separator = " ") {
+                it.sourceId.toString()
+            }
+        } ?: logger.warn("(MismatchedIdDebug) plugin metadata instance is null when adding plugin $this")
+    }
+
+    fun mapTopicAndSource(topicName: String) {
+        metadataStore?.topicToPluginMapper?.putIfAbsent(
+            topicName,
+            pluginName
+        ) ?: logger.warn("(MismatchedIdDebug) plugin metadata instance is null when adding topic $this")
+    }
+
     /**
      * Override this function to get any parameters from the given intent.
      * Bundle classloader needs to be set correctly for this to work.
@@ -394,6 +420,7 @@ abstract class SourceService<T : BaseSourceState> : LifecycleService(), SourceSt
             },
             onFail,
         ) ?: onFail(null)
+        addPluginMetadata()
     }
 
     open fun ensureRegistration(id: String?, name: String?, attributes: Map<String, String>, onMapping: (SourceMetadata?) -> Unit) {

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/MismatchedIdException.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/MismatchedIdException.kt
@@ -1,0 +1,8 @@
+package org.radarbase.android.util
+
+import java.io.IOException
+
+class MismatchedIdException : RuntimeException {
+    constructor(message: String?): super(message)
+    constructor(message: String?, cause: Throwable?): super(message, cause)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/NonFatalCrashlyticsReporter.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/NonFatalCrashlyticsReporter.kt
@@ -1,0 +1,127 @@
+package org.radarbase.android.util
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import org.radarbase.android.util.exceptions.MismatchedProjectIdException
+import org.radarbase.android.util.exceptions.MismatchedSourceIdException
+import org.radarbase.android.util.exceptions.MismatchedUserIdException
+import org.slf4j.LoggerFactory
+
+/**
+ * Reports non-fatal mismatches (source, project, or user IDs) to Firebase Crashlytics.
+ *
+ * This class centralizes reporting logic for mismatched IDs between payloads and
+ * auth tokens
+ */
+class NonFatalCrashlyticsReporter {
+
+    /**
+     * Report a mismatch between the payload's source ID and the token's source ID.
+     *
+     * @param projectId The project identifier.
+     * @param keySourceId The source ID found in the record key.
+     * @param userId The user ID associated with the record key.
+     * @param topic The Kafka topic used for which the payload is published.
+     * @param pluginName The name of the plugin producing the payload.
+     * @param tokenSourceId The source ID extracted from the access token.
+     */
+    fun reportMismatchedSourceId(
+        projectId: String?,
+        keySourceId: String?,
+        userId: String?,
+        topic: String,
+        pluginName: String?,
+        tokenSourceId: String?
+    ) {
+        logger.warn("Reporting MismatchedSourceId to Crashlytics")
+        crashlyticsApplier {
+            setCustomKey("error_type", "source_id_mismatch")
+            setCustomKey("project_id", projectId.orEmpty())
+            setCustomKey("plugin_name", pluginName.orEmpty())
+            setCustomKey("topic", topic)
+            setCustomKey("payload_source_id", keySourceId.orEmpty())
+            setCustomKey("token_source_id", tokenSourceId.orEmpty())
+            setUserId(userId.orEmpty())
+
+            log("Detected sourceId mismatch for plugin=$pluginName, topic=$topic")
+            recordException(
+                MismatchedSourceIdException(
+                    "Payload sourceId=$keySourceId ≠ token sourceId=$tokenSourceId"
+                )
+            )
+        }
+    }
+
+    /**
+     * Report a mismatch between the payload's project ID and the token's project ID.
+     *
+     * @param keyProjectId The project ID found in the payload.
+     * @param tokenProjectId The project ID extracted from the access token.
+     * @param pluginName The name of the plugin producing the payload.
+     * @param topic The Kafka topic used for publishing the payload.
+     * @param userId The user ID associated with the payload.
+     */
+    fun reportMismatchedProjectId(
+        keyProjectId: String?,
+        tokenProjectId: String?,
+        pluginName: String?,
+        topic: String,
+        userId: String?
+    ) {
+        logger.warn("Reporting MismatchedProjectId to Crashlytics")
+        crashlyticsApplier {
+            setCustomKey("error_type", "project_id_mismatch")
+            setCustomKey("key_project_id", keyProjectId.orEmpty())
+            setCustomKey("token_project_id", tokenProjectId.orEmpty())
+            setCustomKey("plugin_name", pluginName.orEmpty())
+            setCustomKey("topic", topic)
+            setUserId(userId.orEmpty())
+
+            log("Detected projectId mismatch when sending data for plugin=$pluginName, topic=$topic")
+            recordException(
+                MismatchedProjectIdException(
+                    "Payload projectId=$keyProjectId ≠ token projectId=$tokenProjectId"
+                )
+            )
+        }
+    }
+
+    /**
+     * Report a mismatch between the payload's user ID and the token's user ID.
+     *
+     * @param keyUserId The user ID found in the payload.
+     * @param tokenUserId The user ID extracted from the access token.
+     * @param pluginName The name of the plugin producing the payload.
+     * @param topic The Kafka topic used for publishing the payload.
+     */
+    fun reportMismatchedUserId(
+        keyUserId: String?,
+        tokenUserId: String?,
+        pluginName: String?,
+        topic: String
+    ) {
+        logger.warn("Reporting MismatchedUserId to Crashlytics")
+        crashlyticsApplier {
+            setCustomKey("error_type", "user_id_mismatch")
+            setCustomKey("key_user_id", keyUserId.orEmpty())
+            setCustomKey("token_user_id", tokenUserId.orEmpty())
+            setUserId(tokenUserId.orEmpty())
+
+            log("Detected userId mismatch when sending data for plugin=$pluginName, topic=$topic")
+            recordException(
+                MismatchedUserIdException(
+                    "Payload userId=$keyUserId ≠ token userId=$tokenUserId"
+                )
+            )
+        }
+    }
+
+    private fun crashlyticsApplier(block: FirebaseCrashlytics.() -> Unit) {
+        Firebase.crashlytics.apply(block)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(NonFatalCrashlyticsReporter::class.java)
+    }
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/NonFatalCrashlyticsReporter.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/NonFatalCrashlyticsReporter.kt
@@ -14,7 +14,8 @@ import org.slf4j.LoggerFactory
  * This class centralizes reporting logic for mismatched IDs between payloads and
  * auth tokens
  */
-class NonFatalCrashlyticsReporter {
+object NonFatalCrashlyticsReporter {
+    private val logger = LoggerFactory.getLogger(NonFatalCrashlyticsReporter::class.java)
 
     /**
      * Report a mismatch between the payload's source ID and the token's source ID.
@@ -121,7 +122,4 @@ class NonFatalCrashlyticsReporter {
         Firebase.crashlytics.apply(block)
     }
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(NonFatalCrashlyticsReporter::class.java)
-    }
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedProjectIdException.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedProjectIdException.kt
@@ -1,0 +1,6 @@
+package org.radarbase.android.util.exceptions
+
+class MismatchedProjectIdException : RuntimeException {
+    constructor(message: String?): super(message)
+    constructor(message: String?, cause: Throwable?): super(message, cause)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedSourceIdException.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedSourceIdException.kt
@@ -1,0 +1,6 @@
+package org.radarbase.android.util.exceptions
+
+class MismatchedSourceIdException : RuntimeException {
+    constructor(message: String?): super(message)
+    constructor(message: String?, cause: Throwable?): super(message, cause)
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedUserIdException.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/exceptions/MismatchedUserIdException.kt
@@ -1,8 +1,6 @@
-package org.radarbase.android.util
+package org.radarbase.android.util.exceptions
 
-import java.io.IOException
-
-class MismatchedIdException : RuntimeException {
+class MismatchedUserIdException : RuntimeException {
     constructor(message: String?): super(message)
     constructor(message: String?, cause: Throwable?): super(message, cause)
 }


### PR DESCRIPTION
Added a data integrity check for cases where the `sourceId` of the data payload doesn't match the token's `sourceId`.
If the IDs don't match, the data is discarded and reported as a non-fatal error to Firebase Crashlytics.
