### PR TITLE
Added Periodic Permission Observer in RadarService

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -366,6 +366,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
                 }
             }
         }
+
+        periodicPermissionObserver.configurePermissionObserver(config)
     }
 
     private fun hasFeatures(provider: SourceProvider<*>, packageManager: PackageManager?): Boolean {

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -420,6 +420,10 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
     }
 
+    fun nonGrantedPermissions(): Set<String> {
+        return needsPermissions
+    }
+
     private fun updateBluetoothNeeded(newValue: Boolean) {
         needsBluetooth.applyIfChanged(newValue) {
             if (newValue) {

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -118,6 +118,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
     }
     private lateinit var notificationHandler: NotificationHandler
+    private lateinit var periodicPermissionObserver: PeriodicPermissionObserver
 
     override fun onBind(intent: Intent): IBinder? {
         super.onBind(intent)
@@ -155,6 +156,9 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         configuration = radarConfig
         providerLoader = SourceProviderLoader(plugins)
         broadcaster = LocalBroadcastManager.getInstance(this)
+        periodicPermissionObserver = PeriodicPermissionObserver(this).apply {
+            start()
+        }
 
         broadcaster.run {
             permissionsBroadcastReceiver = register(ACTION_PERMISSIONS_GRANTED) { _, intent ->
@@ -319,6 +323,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             }
         }
         authConnection.unbind()
+
+        periodicPermissionObserver.stop()
 
         mConnections.asSequence()
             .filter(SourceProvider<*>::isBound)

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
@@ -5,6 +5,9 @@ import com.google.firebase.ktx.Firebase
 import org.radarbase.android.RadarApplication.Companion.radarConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.config.SingleRadarConfiguration
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
 
 class PeriodicPermissionObserver(private val context: RadarService) {
     private var count = 0
@@ -21,30 +24,37 @@ class PeriodicPermissionObserver(private val context: RadarService) {
     private var observerInterval: Long = -1L
 
     fun start() {
-        pObserverProcessor.start()
         configurePermissionObserver(context.radarConfig.latestConfig)
+        pObserverProcessor.start()
     }
 
     private fun observePermissions() {
         count += 1
-        if (isFirstAlarm) return
+        if (isFirstAlarm) {
+            logger.info("This is the first alarm, aborting it")
+            return
+        }
 
         context.nonGrantedPermissions().also { permissions ->
             if (permissions.isNotEmpty()) {
+                logger.info("Some permissions are still not granted: ${permissions.joinToString(", ") { it }}")
                 Firebase.crashlytics.apply {
-                    log("User have not granted some permissions")
+                    log("User has not granted some permissions")
                     setCustomKey("error_type", "permissions_not_granted")
                     setCustomKey("non_granted_permissions", permissions.joinToString(", ") { it })
+                    recordException(RuntimeException("Some permissions have not been granted."))
                 }
             }
         }
     }
 
-    private fun configurePermissionObserver(config: SingleRadarConfiguration) {
+    fun configurePermissionObserver(config: SingleRadarConfiguration) {
         observerInterval = config.getLong(
             PERMISSION_OBSERVER_INTERVAL_SECONDS,
             PERMISSION_OBSERVER_INTERVAL_SECONDS_DEFAULT
         )
+
+        pObserverProcessor.interval(observerInterval, TimeUnit.SECONDS)
     }
 
 
@@ -53,12 +63,13 @@ class PeriodicPermissionObserver(private val context: RadarService) {
     }
 
     companion object {
+        private val logger: Logger = LoggerFactory.getLogger(PeriodicPermissionObserver::class.java)
+
         private const val PERIODIC_PERMISSION_OBSERVER_REQUEST_CODE = 683768762
         private const val PERIODIC_PERMISSION_OBSERVER_REQUEST_NAME =
             "org.radarbase.android.util.PeriodicPermissionObserver.PERIODIC_PERMISSION_OBSERVER_REQUEST_NAME"
         private const val PERMISSION_OBSERVER_INTERVAL_SECONDS =
             "org.radarbase.android.util.PeriodicPermissionObserver.PERMISSION_OBSERVER_INTERVAL_SECONDS"
-        private const val PERMISSION_OBSERVER_INTERVAL_SECONDS_DEFAULT =
-            2L * ((60 * 60) * 24) // 2-DAYS
+        private const val PERMISSION_OBSERVER_INTERVAL_SECONDS_DEFAULT = 2L * ((60 * 60) * 24) // 2-DAYS
     }
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
@@ -1,0 +1,65 @@
+package org.radarbase.android.util
+
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import org.radarbase.android.RadarApplication.Companion.radarConfig
+import org.radarbase.android.RadarService
+import org.radarbase.android.config.SingleRadarConfiguration
+
+class PeriodicPermissionObserver(private val context: RadarService) {
+    private var count = 0
+    private val isFirstAlarm: Boolean
+        get() = count <= 1
+
+    private val pObserverProcessor = OfflineProcessor(context) {
+        process = listOf(this@PeriodicPermissionObserver::observePermissions)
+        requestCode = PERIODIC_PERMISSION_OBSERVER_REQUEST_CODE
+        requestName = PERIODIC_PERMISSION_OBSERVER_REQUEST_NAME
+        wake = false
+    }
+
+    private var observerInterval: Long = -1L
+
+    fun start() {
+        pObserverProcessor.start()
+        configurePermissionObserver(context.radarConfig.latestConfig)
+    }
+
+    private fun observePermissions() {
+        count += 1
+        if (isFirstAlarm) return
+
+        val permissions = context.nonGrantedPermissions()
+
+        if (permissions.isNotEmpty()) {
+            Firebase.crashlytics.apply {
+                log("User have not granted some permissions")
+                setCustomKey("error_type", "permissions_not_granted")
+                setCustomKey("non_granted_permissions", permissions.joinToString(", ") { it })
+            }
+        }
+
+    }
+
+    private fun configurePermissionObserver(config: SingleRadarConfiguration) {
+        observerInterval = config.getLong(
+            PERMISSION_OBSERVER_INTERVAL_SECONDS,
+            PERMISSION_OBSERVER_INTERVAL_SECONDS_DEFAULT
+        )
+    }
+
+
+    fun stop() {
+
+    }
+
+    companion object {
+        private const val PERIODIC_PERMISSION_OBSERVER_REQUEST_CODE = 683768762
+        private const val PERIODIC_PERMISSION_OBSERVER_REQUEST_NAME =
+            "org.radarbase.android.util.PeriodicPermissionObserver.PERIODIC_PERMISSION_OBSERVER_REQUEST_NAME"
+        private const val PERMISSION_OBSERVER_INTERVAL_SECONDS =
+            "org.radarbase.android.util.PeriodicPermissionObserver.PERMISSION_OBSERVER_INTERVAL_SECONDS"
+        private const val PERMISSION_OBSERVER_INTERVAL_SECONDS_DEFAULT =
+            2L * ((60 * 60) * 24) // 2-DAYS
+    }
+}

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PeriodicPermissionObserver.kt
@@ -29,16 +29,15 @@ class PeriodicPermissionObserver(private val context: RadarService) {
         count += 1
         if (isFirstAlarm) return
 
-        val permissions = context.nonGrantedPermissions()
-
-        if (permissions.isNotEmpty()) {
-            Firebase.crashlytics.apply {
-                log("User have not granted some permissions")
-                setCustomKey("error_type", "permissions_not_granted")
-                setCustomKey("non_granted_permissions", permissions.joinToString(", ") { it })
+        context.nonGrantedPermissions().also { permissions ->
+            if (permissions.isNotEmpty()) {
+                Firebase.crashlytics.apply {
+                    log("User have not granted some permissions")
+                    setCustomKey("error_type", "permissions_not_granted")
+                    setCustomKey("non_granted_permissions", permissions.joinToString(", ") { it })
+                }
             }
         }
-
     }
 
     private fun configurePermissionObserver(config: SingleRadarConfiguration) {
@@ -50,7 +49,7 @@ class PeriodicPermissionObserver(private val context: RadarService) {
 
 
     fun stop() {
-
+        pObserverProcessor.close()
     }
 
     companion object {


### PR DESCRIPTION
A permission observer in RadarService is added to check whether all required permissions have been granted periodically. If they are not, the missing permissions are logged to Firebase Crashlytics as non-fatal logs.

