### PR TITLE
Update project version and grep correct project version

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Has SNAPSHOT version
         id: is-snapshot
-        run: grep 'version = ".*-SNAPSHOT"' build.gradle
+        run: grep 'project_version=.*-SNAPSHOT' gradle.properties
 
       - uses: actions/setup-java@v3
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.defaults.buildfeatures.buildconfig=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-project_version=1.5.3
+project_version=1.6.0-SNAPSHOT
 
 java_version=17
 kotlin_version=1.9.23


### PR DESCRIPTION
The `publish-snapshots.yml` workflow was checking `build.gradle` for a `-SNAPSHOT` suffix, but `build.gradle` uses `version = "$project_version` which references `gradle.properties`. The grep would never match. 
This PR corrects this to check for correct variable.