### PR TITLE
Fix Play Store rejection, prominent disclosure for ACCESS_BACKGROUND_LOCATION

### DIFF
--- a/radar-commons-android/src/main/res/layout/background_location_dialog.xml
+++ b/radar-commons-android/src/main/res/layout/background_location_dialog.xml
@@ -17,6 +17,7 @@
             android:contentDescription="@string/bg_location_disclosure_title" />
 
         <TextView
+            android:id="@+id/bg_location_disclosure_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
@@ -26,6 +27,7 @@
             android:textStyle="bold" />
 
         <TextView
+            android:id="@+id/bg_location_disclosure_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
@@ -35,6 +37,7 @@
             android:autoLink="web" />
 
         <TextView
+            android:id="@+id/bg_location_disclosure_revoke_hint"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"

--- a/radar-commons-android/src/main/res/layout/background_location_dialog.xml
+++ b/radar-commons-android/src/main/res/layout/background_location_dialog.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="32dp"
+        android:paddingHorizontal="24dp">
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:src="@drawable/baseline_location_on_green_700_48dp"
+            android:contentDescription="@string/bg_location_disclosure_title" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/bg_location_disclosure_title"
+            android:textAlignment="center"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/bg_location_disclosure_body"
+            android:textIsSelectable="true"
+            android:linksClickable="true"
+            android:autoLink="web" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/bg_location_disclosure_revoke_hint"
+            android:textStyle="italic" />
+    </LinearLayout>
+</ScrollView>

--- a/radar-commons-android/src/main/res/layout/location_dialog.xml
+++ b/radar-commons-android/src/main/res/layout/location_dialog.xml
@@ -16,7 +16,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="32dp"
-        android:text="@string/location_bg_dialog_title"
+        android:text="@string/location_dialog_title"
         android:textAlignment="center"
         android:textSize="20sp"
         android:textStyle="bold" />
@@ -25,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="32dp"
-        android:text="@string/location_bg_dialog_message"
+        android:text="@string/location_dialog_message"
         />
 
     <TextView

--- a/radar-commons-android/src/main/res/values/strings.xml
+++ b/radar-commons-android/src/main/res/values/strings.xml
@@ -9,13 +9,16 @@
     <string name="retry_oauth_login">Failed to login to authorization service, please retry</string>
     <string name="login_failed">Failed to log in</string>
 
-    <string name="location_bg_dialog_title">pRMT App uses your \"Location in Background\"</string>
-    <string name="location_bg_dialog_message">This app collects location data to enable Bluetooth Low Energy and/or location tracking as
-        part of the study even when the app is closed or not in use.</string>
     <string name="dialog_usage">The researcher(s) only use the collected data in the study you consented to.</string>
 
-    <string name="location_dialog_title">pRMT App uses your \"Location\"</string>
+    <string name="location_dialog_title">This app uses your \"Location\"</string>
     <string name="location_dialog_message">Location information is needed to enable Bluetooth Low Energy and/or location tracking as part of the study.</string>
+
+    <string name="bg_location_disclosure_title">Allow background location access?</string>
+    <string name="bg_location_disclosure_body">This app collects your device location, including when the app is closed or not in use, to keep your connected study device (e.g. Bluetooth wearable) reachable and to record location samples for the research study you consented to. Location data is uploaded to the study server you agreed to. Tap Accept to be asked by Android for the &quot;Allow all the time&quot; location permission.</string>
+    <string name="bg_location_disclosure_revoke_hint">You can revoke this permission at any time from Android Settings.</string>
+    <string name="disclosure_accept">Accept</string>
+    <string name="disclosure_reject">Reject</string>
 
     <string name="usage_tracking_dialog_title">Enable \"Usage tracking\"</string>
     <string name="usage_tracking_dialog_message">Enable usage access to keep track of what kind of applications you use.</string>


### PR DESCRIPTION
Google Play rejected the release for missing a prominent in-app disclosure preceding the `ACCESS_BACKGROUND_LOCATION` runtime request

Added a dedicated `background_location_dialog.xml` layout shown immediately before the OS background-location prompt (matches the Play prominent-disclosure policy).