### PR TITLE
Sequential permission dialogs and remote configurable background-location disclosure

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -108,6 +108,10 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
 
+        const val BG_LOCATION_DISCLOSURE_TITLE_KEY = "bg_location_disclosure_title"
+        const val BG_LOCATION_DISCLOSURE_BODY_KEY = "bg_location_disclosure_body"
+        const val BG_LOCATION_DISCLOSURE_REVOKE_HINT_KEY = "bg_location_disclosure_revoke_hint"
+
         const val SEND_ONLY_WITH_WIFI_DEFAULT = true
         const val SEND_OVER_DATA_HIGH_PRIORITY_DEFAULT = true
         const val SEND_BINARY_CONTENT_DEFAULT = true

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
@@ -17,11 +17,15 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.os.Process
 import android.provider.Settings
+import android.view.View
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.radarbase.android.R
+import org.radarbase.android.RadarApplication.Companion.radarConfig
+import org.radarbase.android.RadarConfiguration
 import org.radarbase.android.RadarService
 import org.radarbase.android.RadarService.Companion.ACCESS_BACKGROUND_LOCATION_COMPAT
 import org.slf4j.LoggerFactory
@@ -38,9 +42,11 @@ open class PermissionHandler(
     private val isRequestingPermissions: MutableSet<String> = HashSet()
     private var isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
     private var requestFuture: SafeHandler.HandlerFuture? = null
+    private var isShowingDialog = false
 
     private fun onPermissionRequestResult(permission: String, granted: Boolean) {
         mHandler.execute {
+            isShowingDialog = false
             needsPermissions.remove(permission)
 
             val result = if (granted) PERMISSION_GRANTED else PERMISSION_DENIED
@@ -65,6 +71,9 @@ open class PermissionHandler(
     }
 
     private fun doRequestPermission() {
+        if (isShowingDialog) {
+            return
+        }
         val externallyGrantedPermissions = needsPermissions.filterTo(HashSet()) { activity.isPermissionGranted(it) }
 
         if (externallyGrantedPermissions.isNotEmpty()) {
@@ -81,7 +90,7 @@ open class PermissionHandler(
         val currentlyNeeded = buildSet(needsPermissions.size) {
             addAll(needsPermissions)
             removeAll(isRequestingPermissions)
-            if (contains(ACCESS_COARSE_LOCATION) || contains(ACCESS_FINE_LOCATION)) {
+            if (ACCESS_COARSE_LOCATION in needsPermissions || ACCESS_FINE_LOCATION in needsPermissions) {
                 remove(RadarService.ACCESS_BACKGROUND_LOCATION_COMPAT)
             }
         }
@@ -122,13 +131,41 @@ open class PermissionHandler(
             }
             else -> {
                 addRequestingPermissions(currentlyNeeded)
+                isShowingDialog = true
                 requestPermissions(currentlyNeeded)
             }
         }
     }
 
     private fun requestBackgroundLocationPermissions() {
-        requestPermissions(setOf(ACCESS_BACKGROUND_LOCATION_COMPAT))
+        alertDialog {
+            val view = activity.layoutInflater
+                .inflate(R.layout.background_location_dialog, null)
+            applyDisclosureOverrides(view)
+            setView(view)
+            setCancelable(false)
+            setPositiveButton(R.string.disclosure_accept) { dialog, _ ->
+                dialog.dismiss()
+                requestPermissions(setOf(ACCESS_BACKGROUND_LOCATION_COMPAT))
+            }
+            setNegativeButton(R.string.disclosure_reject) { dialog, _ ->
+                dialog.cancel()
+                onPermissionRequestResult(ACCESS_BACKGROUND_LOCATION_COMPAT, false)
+            }
+        }
+    }
+
+    private fun applyDisclosureOverrides(view: View) {
+        val config = activity.radarConfig.latestConfig
+        config.optString(RadarConfiguration.BG_LOCATION_DISCLOSURE_TITLE_KEY)
+            ?.takeIf(String::isNotBlank)
+            ?.let { view.findViewById<TextView>(R.id.bg_location_disclosure_title)?.text = it }
+        config.optString(RadarConfiguration.BG_LOCATION_DISCLOSURE_BODY_KEY)
+            ?.takeIf(String::isNotBlank)
+            ?.let { view.findViewById<TextView>(R.id.bg_location_disclosure_body)?.text = it }
+        config.optString(RadarConfiguration.BG_LOCATION_DISCLOSURE_REVOKE_HINT_KEY)
+            ?.takeIf(String::isNotBlank)
+            ?.let { view.findViewById<TextView>(R.id.bg_location_disclosure_revoke_hint)?.text = it }
     }
 
     private fun requestLocationPermissions(locationPermissions: Set<String>) {
@@ -160,6 +197,7 @@ open class PermissionHandler(
     private fun resetRequestingPermission() {
         isRequestingPermissions.clear()
         isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
+        isShowingDialog = false
     }
 
     private fun addRequestingPermissions(permission: String) {
@@ -179,20 +217,33 @@ open class PermissionHandler(
     }
 
     private fun alertDialog(configure: AlertDialog.Builder.() -> Unit) {
+        isShowingDialog = true
         try {
             activity.runOnUiThread {
-                AlertDialog.Builder(activity, android.R.style.Theme_Material_Dialog_Alert)
-                    .apply(configure)
-                    .show()
+                try {
+                    AlertDialog.Builder(activity, android.R.style.Theme_Material_Dialog_Alert)
+                        .apply(configure)
+                        .setOnCancelListener {
+                            mHandler.execute {
+                                isShowingDialog = false
+                                requestPermissions()
+                            }
+                        }
+                        .show()
+                } catch (ex: IllegalStateException) {
+                    logger.warn("Cannot show dialog on closing activity")
+                    mHandler.execute { isShowingDialog = false }
+                }
             }
         } catch (ex: IllegalStateException) {
             logger.warn("Cannot show dialog on closing activity")
+            isShowingDialog = false
         }
     }
 
     private fun requestLocationProvider() {
         alertDialog {
-            setView(R.layout.location_dialog)
+            setView(R.layout.enable_location_dialog)
             setPositiveButton(android.R.string.ok) { dialog, _ ->
                 dialog.dismiss()
                 Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
@@ -333,6 +384,10 @@ open class PermissionHandler(
             broadcaster.send(RadarService.ACTION_PERMISSIONS_GRANTED) {
                 putExtra(RadarService.EXTRA_PERMISSIONS, permissions)
                 putExtra(RadarService.EXTRA_GRANT_RESULTS, grantResults)
+            }
+            mHandler.execute {
+                isShowingDialog = false
+                requestPermissions()
             }
         }
     }

--- a/radar-commons-android/src/main/res/layout/enable_location_dialog.xml
+++ b/radar-commons-android/src/main/res/layout/enable_location_dialog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingVertical="64dp"
+    android:paddingHorizontal="16dp">
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:src="@drawable/baseline_location_on_green_700_48dp"
+        />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="@string/enable_location_dialog_title"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="@string/enable_location_dialog_message"
+        />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="@string/dialog_usage"
+        />
+
+</LinearLayout>

--- a/radar-commons-android/src/main/res/values/strings.xml
+++ b/radar-commons-android/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="location_dialog_title">This app uses your \"Location\"</string>
     <string name="location_dialog_message">Location information is needed to enable Bluetooth Low Energy and/or location tracking as part of the study.</string>
 
+    <string name="enable_location_dialog_title">Turn on Location</string>
+    <string name="enable_location_dialog_message">Location services are turned off on your device. Tap OK to open Settings and turn them on so the study can keep collecting data.</string>
+
     <string name="bg_location_disclosure_title">Allow background location access?</string>
     <string name="bg_location_disclosure_body">This app collects your device location, including when the app is closed or not in use, to keep your connected study device (e.g. Bluetooth wearable) reachable and to record location samples for the research study you consented to. Location data is uploaded to the study server you agreed to. Tap Accept to be asked by Android for the &quot;Allow all the time&quot; location permission.</string>
     <string name="bg_location_disclosure_revoke_hint">You can revoke this permission at any time from Android Settings.</string>


### PR DESCRIPTION
I noticed when adding the new dialog for background location -- permission requests no longer stack on top of each other. Each step now waits for the previous one to resolve before the next dialog opens, so participants can complete them in order. A dedicated "Turn on Location" dialog now makes the trip to system Settings, separate from the foreground rationale earlier in the flow. The background-location disclosure (title, body and revoke hint) can also be overridden from Remote Config, so the text can be updated per study.
