### PR TITLE
Recover permission flow when Settings doesn't report a return

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -138,6 +138,7 @@ abstract class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        permissionHandler.onActivityResumed()
         uiUpdater = mHandler.repeat(uiRefreshRate) {
             try {
                 // Update all rows in the UI with the data from the connections

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
@@ -357,9 +357,6 @@ open class PermissionHandler(
     fun onActivityResumed() {
         mHandler.execute {
             if (!isShowingDialog || !awaitingExternalCallback) return@execute
-            // External callback (onActivityResult / onRequestPermissionsResult) never arrived —
-            // happens on some OEM ROMs (e.g. ColorOS) when the user backs out of Settings.
-            // Sync each pending permission against the live state and advance.
             val pending = isRequestingPermissions.toSet()
             pending.forEach { permission ->
                 val granted = activity.isPermissionGranted(permission)

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
@@ -43,6 +43,7 @@ open class PermissionHandler(
     private var isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
     private var requestFuture: SafeHandler.HandlerFuture? = null
     private var isShowingDialog = false
+    private var awaitingExternalCallback = false
 
     private fun onPermissionRequestResult(permission: String, granted: Boolean) {
         mHandler.execute {
@@ -189,6 +190,7 @@ open class PermissionHandler(
                 permissions.toTypedArray(),
                 REQUEST_ENABLE_PERMISSIONS,
             )
+            mHandler.execute { awaitingExternalCallback = true }
         } catch (ex: IllegalStateException) {
             logger.warn("Cannot request permission on closing activity")
         }
@@ -198,6 +200,7 @@ open class PermissionHandler(
         isRequestingPermissions.clear()
         isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
         isShowingDialog = false
+        awaitingExternalCallback = false
     }
 
     private fun addRequestingPermissions(permission: String) {
@@ -279,6 +282,7 @@ open class PermissionHandler(
         resolveActivity(activity.packageManager) ?: return
         try {
             activity.startActivityForResult(this, code)
+            mHandler.execute { awaitingExternalCallback = true }
         } catch (ex: ActivityNotFoundException) {
             logger.error("Failed to ask for usage code", ex)
         } catch (ex: IllegalStateException) {
@@ -323,6 +327,7 @@ open class PermissionHandler(
     }
 
     fun onActivityResult(requestCode: Int, resultCode: Int) {
+        mHandler.execute { awaitingExternalCallback = false }
         when (requestCode) {
             LOCATION_REQUEST_CODE -> onPermissionRequestResult(
                 LOCATION_SERVICE,
@@ -346,6 +351,31 @@ open class PermissionHandler(
                 SYSTEM_ALERT_WINDOW,
                 resultCode == Activity.RESULT_OK
             )
+        }
+    }
+
+    fun onActivityResumed() {
+        mHandler.execute {
+            if (!isShowingDialog || !awaitingExternalCallback) return@execute
+            // External callback (onActivityResult / onRequestPermissionsResult) never arrived —
+            // happens on some OEM ROMs (e.g. ColorOS) when the user backs out of Settings.
+            // Sync each pending permission against the live state and advance.
+            val pending = isRequestingPermissions.toSet()
+            pending.forEach { permission ->
+                val granted = activity.isPermissionGranted(permission)
+                needsPermissions.remove(permission)
+                broadcaster.send(RadarService.ACTION_PERMISSIONS_GRANTED) {
+                    putExtra(RadarService.EXTRA_PERMISSIONS, arrayOf(permission))
+                    putExtra(
+                        RadarService.EXTRA_GRANT_RESULTS,
+                        intArrayOf(if (granted) PERMISSION_GRANTED else PERMISSION_DENIED),
+                    )
+                }
+                isRequestingPermissions.remove(permission)
+            }
+            isShowingDialog = false
+            awaitingExternalCallback = false
+            requestPermissions()
         }
     }
 
@@ -387,6 +417,7 @@ open class PermissionHandler(
             }
             mHandler.execute {
                 isShowingDialog = false
+                awaitingExternalCallback = false
                 requestPermissions()
             }
         }


### PR DESCRIPTION
On some old androids, backing out of the system Settings page silently drops the return signal to the app, so the permission queue used to stall on the current step and participants had to relaunch the app for the next dialog to appear. The activity now does a recovery whenever it comes back to the foreground. 
If we're still waiting for a system result that should have arrived by then, we read each pending permission's live state and let the queue move on, so the next dialog opens on its own once the participant is back. Standard Androids stay unaffected, since the real signal arrives first in the lifecycle and clears the wait before `onResume` runs.
