### PR TITLE
Promote the radar service to foreground only after permissions are granted

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
@@ -43,4 +43,6 @@ interface IRadarBinder : IBinder {
     fun stopScanning()
 
     fun needsBluetooth(): Boolean
+
+    fun checkPermissions()
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -16,8 +16,21 @@
 
 package org.radarbase.android
 
+import android.Manifest.permission.ACCESS_COARSE_LOCATION
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.ACTIVITY_RECOGNITION
+import android.Manifest.permission.BLUETOOTH_ADVERTISE
+import android.Manifest.permission.BLUETOOTH_CONNECT
+import android.Manifest.permission.BLUETOOTH_SCAN
+import android.Manifest.permission.BODY_SENSORS
+import android.Manifest.permission.RECORD_AUDIO
+import android.Manifest.permission.UWB_RANGING
 import android.content.Context
 import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.Q
+import android.os.Build.VERSION_CODES.S
+import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
 import android.os.Process
 import androidx.annotation.CallSuper
@@ -37,6 +50,7 @@ import org.radarbase.android.RadarService.Companion.EXTRA_PERMISSIONS
 import org.radarbase.android.auth.AuthService
 import org.radarbase.android.config.CombinedRadarConfig
 import org.radarbase.android.util.*
+import org.radarbase.android.util.PermissionHandler.Companion.isPermissionGranted
 import org.slf4j.LoggerFactory
 
 /** Base MainActivity class. It manages the services to collect the data and starts up a view. To
@@ -165,15 +179,8 @@ abstract class MainActivity : AppCompatActivity() {
         authConnection.bind()
         bluetoothEnforcer.start()
 
-        val radarServiceCls = radarApp.radarService
-        try {
-            val intent = Intent(this, radarServiceCls)
-            ContextCompat.startForegroundService(this, intent)
-        } catch (ex: IllegalStateException) {
-            logger.error("Failed to start RadarService: activity is in background.", ex)
-        }
-
         radarConnection.bind()
+        maybeStartRadarServiceAsForeground()
 
         permissionHandler.invalidateCache()
 
@@ -217,6 +224,7 @@ abstract class MainActivity : AppCompatActivity() {
         }
         bluetoothEnforcer.onActivityResult(requestCode, resultCode)
         permissionHandler.onActivityResult(requestCode, resultCode)
+        maybeStartRadarServiceAsForeground()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
@@ -225,6 +233,34 @@ abstract class MainActivity : AppCompatActivity() {
             mHandler.start()
         }
         permissionHandler.permissionsGranted(requestCode, permissions, grantResults)
+        maybeStartRadarServiceAsForeground()
+    }
+
+    private fun maybeStartRadarServiceAsForeground() {
+        if (SDK_INT >= UPSIDE_DOWN_CAKE && !hasAnyTypedFgsPermission()) {
+            return
+        }
+        try {
+            val intent = Intent(this, radarApp.radarService)
+            ContextCompat.startForegroundService(this, intent)
+        } catch (ex: IllegalStateException) {
+            logger.error("Failed to start RadarService: activity is in background.", ex)
+        }
+    }
+
+    private fun hasAnyTypedFgsPermission(): Boolean {
+        if (isPermissionGranted(ACCESS_COARSE_LOCATION)) return true
+        if (isPermissionGranted(ACCESS_FINE_LOCATION)) return true
+        if (isPermissionGranted(RECORD_AUDIO)) return true
+        if (SDK_INT >= Q && isPermissionGranted(ACTIVITY_RECOGNITION)) return true
+        if (isPermissionGranted(BODY_SENSORS)) return true
+        if (SDK_INT >= S) {
+            if (isPermissionGranted(BLUETOOTH_CONNECT)) return true
+            if (isPermissionGranted(BLUETOOTH_SCAN)) return true
+            if (isPermissionGranted(BLUETOOTH_ADVERTISE)) return true
+            if (isPermissionGranted(UWB_RANGING)) return true
+        }
+        return false
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -107,6 +107,7 @@ abstract class MainActivity : AppCompatActivity() {
 
         radarConnection = ManagedServiceConnection<IRadarBinder>(this@MainActivity, radarApp.radarService).apply {
             bindFlags = Context.BIND_ABOVE_CLIENT or Context.BIND_AUTO_CREATE
+            onBoundListeners += IRadarBinder::checkPermissions
             onBoundListeners += IRadarBinder::startScanning
             onBoundListeners += { binder -> view?.onRadarServiceBound(binder) }
             onUnboundListeners += IRadarBinder::stopScanning

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -27,7 +27,6 @@ import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.*
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -235,18 +234,33 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             // Below API 34: Start foreground without service types
             startForeground(1, createForegroundNotification())
         } else {
-
-            /**
-             * API 34+ (Android 14+): Adding DATA_SYNC type
-             * Currently this is not explicitly checking for android 14+ version.
-             * This need to be modified it in future when setting new targetSdkVersion
-             */
-            startForeground(1, createForegroundNotification(),
-                        FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-            )
+            val grantedTyped = currentlyGrantedTypedFgsPermissions()
+            if (grantedTyped.isEmpty()) {
+                logger.warn("startForegroundService called without any typed FGS permission, stopping to avoid the 5s deadline")
+                stopSelf(startId)
+                return START_NOT_STICKY
+            }
+            startForegroundIfNeeded(grantedTyped)
         }
 
         return START_STICKY
+    }
+
+    private fun currentlyGrantedTypedFgsPermissions(): Set<String> = buildSet {
+        fun maybeAdd(permission: String) {
+            if (isPermissionGranted(permission)) add(permission)
+        }
+        maybeAdd(ACCESS_COARSE_LOCATION)
+        maybeAdd(ACCESS_FINE_LOCATION)
+        maybeAdd(RECORD_AUDIO)
+        if (SDK_INT >= Q) maybeAdd(ACTIVITY_RECOGNITION)
+        maybeAdd(BODY_SENSORS)
+        if (SDK_INT >= S) {
+            maybeAdd(BLUETOOTH_CONNECT)
+            maybeAdd(BLUETOOTH_SCAN)
+            maybeAdd(BLUETOOTH_ADVERTISE)
+            maybeAdd(UWB_RANGING)
+        }
     }
 
     private fun startForegroundIfNeeded(grantedPermissions: Set<String>) {
@@ -277,10 +291,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
 
         if (fgsTypePermissions.isNotEmpty()) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
-
             val combinedFgsType: Int = fgsTypePermissions.reduce { acc, type -> acc or type }
-
             startForeground(
                 1, createForegroundNotification(),
                 combinedFgsType
@@ -392,7 +403,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
 
         if (grantedPermissions.isNotEmpty()) {
-            startForegroundIfNeeded(grantedPermissions)
+            startForegroundIfNeeded(currentlyGrantedTypedFgsPermissions())
             mHandler.execute {
                 logger.info("Granted permissions {}", grantedPermissions)
                 // Permission granted.

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -702,6 +702,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         override fun startScanning() = this@RadarService.startActiveScanning()
         override fun stopScanning() = this@RadarService.stopActiveScanning()
 
+        override fun checkPermissions() = this@RadarService.checkPermissions()
+
         override val serverStatus: ServerStatusListener.Status
             get() = this@RadarService.serverStatus
 


### PR DESCRIPTION
Previously the service was started directly as a foreground service on launch and used `specialUse` as a placeholder type, since no real permission was held yet.
Google Play treats that pattern as misuse, which is why the latest pRMT submission was rejected.

 Now the service is initialized as a bound service first, and only promoted to a foreground service once at least one of the real runtime permissions (location,  health, microphone, or connected device) is granted. The permission callbacks re-attempt the promotion from bound to foreground service as soon as the first one (related) is granted, so the user-facing flow is unchanged.
