### PR TITLE
Fix crash when granting multiple permissions in sequence

### DIFF
--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -381,12 +381,13 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
     }
 
     private fun requestPermissions(permissions: Collection<String>) {
+        val permissionArray = permissions.toTypedArray()
         mainHandler.post {
             startActivity(Intent(this, radarApp.mainActivity).apply {
                 action = ACTION_CHECK_PERMISSIONS
                 addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                putExtra(EXTRA_PERMISSIONS, permissions.toTypedArray())
+                putExtra(EXTRA_PERMISSIONS, permissionArray)
             })
         }
     }


### PR DESCRIPTION
In `RadarService.requestPermissions`, `.toTypedArray()` was being called inside the `mainHandler.post` lambda, so the set of pending permissions was being copied on the main thread while the background thread that owns it could still mutate it. 

When permissions were granted in quick succession, the copy could over run and crash with `ArrayIndexOutOfBoundsException`. Moving the snapshot out of the lambda so it runs on the calling thread before posting fixes the race.
