### PR TITLE
Narrow foreground service types and add grouped source info

### DIFF
--- a/plugins/radar-android-phone-usage/src/main/java/org/radarbase/passive/phone/usage/PhoneUsageProvider.kt
+++ b/plugins/radar-android-phone-usage/src/main/java/org/radarbase/passive/phone/usage/PhoneUsageProvider.kt
@@ -21,11 +21,14 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 
 class PhoneUsageProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
 
     override val description: String
         get() = radarService.getString(R.string.phone_usage_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneUsageService> = PhoneUsageService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
@@ -21,6 +21,7 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.android.util.BluetoothStateReceiver.Companion.bluetoothPermissionList
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
@@ -28,6 +29,8 @@ import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 open class PhoneBluetoothProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_bluetooth_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneBluetoothService> = PhoneBluetoothService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneContactListProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneContactListProvider.kt
@@ -21,12 +21,15 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 
 open class PhoneContactListProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_contact_list_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneContactsListService> = PhoneContactsListService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneLocationProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneLocationProvider.kt
@@ -23,12 +23,15 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 
 open class PhoneLocationProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_location_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneLocationService> = PhoneLocationService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorProvider.kt
@@ -19,6 +19,7 @@ package org.radarbase.passive.phone
 import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 
 open class PhoneSensorProvider(radarService: RadarService) : SourceProvider<PhoneState>(radarService) {
     override val serviceClass: Class<PhoneSensorService> = PhoneSensorService::class.java
@@ -32,6 +33,8 @@ open class PhoneSensorProvider(radarService: RadarService) : SourceProvider<Phon
 
     override val description: String
         get() = radarService.getString(R.string.phone_sensors_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val displayName: String
         get() = radarService.getString(R.string.phoneServiceDisplayName)

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -107,6 +107,7 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_ID = "oauth2_client_id"
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
+        const val ENABLE_SOURCE_INFO_UI = "enable_source_info_ui"
 
         const val BG_LOCATION_DISCLOSURE_TITLE_KEY = "bg_location_disclosure_title"
         const val BG_LOCATION_DISCLOSURE_BODY_KEY = "bg_location_disclosure_body"

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -24,9 +24,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
 import android.os.*
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -129,16 +127,11 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
 
     private var bluetoothNotification: NotificationHandler.NotificationRegistration? = null
 
-    @RequiresApi(Q)
-    val fgsHealthPermissions: Set<String> = setOf(BODY_SENSORS, ACTIVITY_RECOGNITION)
     @RequiresApi(S)
     val fgsConnectDevicePermissions: Set<String> =
         setOf(BLUETOOTH_CONNECT, BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE, UWB_RANGING)
     private val fgsLocationPermissions: Set<String> =
         setOf(ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION)
-    private val fgsMicrophonePermissions: Set<String> =
-        setOf(RECORD_AUDIO)
-
 
     /** Defines callbacks for service binding, passed to bindService()  */
     private lateinit var bluetoothReceiver: BluetoothStateReceiver
@@ -274,20 +267,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             }
         }
 
-        if (grantedPermissions.intersect(fgsHealthPermissions)
-                .isNotEmpty() && (SDK_INT >= UPSIDE_DOWN_CAKE)
-        ) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_HEALTH)
-        }
-
         if (grantedPermissions.intersect(fgsLocationPermissions).isNotEmpty()) {
             fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_LOCATION)
-        }
-
-        if (grantedPermissions.intersect(fgsMicrophonePermissions)
-                .isNotEmpty() && (SDK_INT >= VERSION_CODES.R)
-        ) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_MICROPHONE)
         }
 
         if (fgsTypePermissions.isNotEmpty()) {
@@ -777,7 +758,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
 
         private const val BLUETOOTH_NOTIFICATION = 521290
 
-        val ACCESS_BACKGROUND_LOCATION_COMPAT = if (SDK_INT >= VERSION_CODES.Q)
+        val ACCESS_BACKGROUND_LOCATION_COMPAT = if (SDK_INT >= Q)
             ACCESS_BACKGROUND_LOCATION else "android.permission.ACCESS_BACKGROUND_LOCATION"
 
         private const val BACKGROUND_REQUEST_CODE = 9559

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
@@ -200,6 +200,14 @@ abstract class SourceProvider<T : BaseSourceState>(protected val radarService: R
     open val isDisplayable: Boolean = true
 
     /**
+     * Identifier that groups several providers together. Providers that
+     * share a non-null [infoGroup] describe a single displayed row collectively, so opening the info
+     * view of the one visible provider can list every grouped provider's [displayName] and
+     * [description]. Defaults to null, meaning the provider stands on its own.
+     */
+    open val infoGroup: String? = null
+
+    /**
      * Whether the source name should be checked with given filters before a connection is allowed
      */
     open val isFilterable: Boolean = false
@@ -253,6 +261,12 @@ abstract class SourceProvider<T : BaseSourceState>(protected val radarService: R
         const val PLUGIN_NAME_KEY = "org.radarbase.android.source.SourceProvider.pluginName"
         const val PRODUCER_KEY = "org.radarbase.android.source.SourceProvider.sourceProducer"
         const val MODEL_KEY = "org.radarbase.android.source.SourceProvider.sourceModel"
+
+        /**
+         * Well-known [infoGroup] shared by the phone plugins (sensors, bluetooth, contacts,
+         * location, usage) so they are described together on the single visible phone row.
+         */
+        const val PHONE_INFO_GROUP = "phone"
 
         private val logger = LoggerFactory.getLogger(SourceProvider::class.java)
     }


### PR DESCRIPTION
Before, the service could also run as a health or microphone foreground service when those permissions were present. Now it only runs as location and connected device, matching what the Play Store build declares. It also adds a way for related sources to be grouped so a single row can describe everything it collects, which the app uses to list the phone sensors together.

Like: 

https://github.com/user-attachments/assets/91907d7c-8123-4620-a891-d078727d5cd7



