### PR TITLE
Use project data from non conditional config and auth state

### DIFF
--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
@@ -17,7 +17,6 @@ import org.radarbase.android.data.DataCache
 import org.radarbase.android.source.AbstractSourceManager
 import org.radarbase.android.source.SourceStatusListener
 import org.radarbase.android.util.SafeHandler
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 import org.radarcns.kafka.ObservationKey
 import org.radarcns.passive.polar.*
 import org.slf4j.LoggerFactory
@@ -50,7 +49,7 @@ class PolarManager(
     private var isDeviceConnected: Boolean = false
 
     @Volatile
-    var uiEnabled: Boolean = POLAR_UI_ENABLED_DEFAULT
+    var uiEnabled: Boolean = false
 
     private var autoConnectDisposable: Disposable? = null
     private var hrDisposable: Disposable? = null

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -12,8 +12,6 @@ import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_KEY
 import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_NAME
 import org.radarbase.passive.polar.ui.PolarActivity
 import androidx.core.content.edit
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_CONFIG
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 
 open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState>(radarService) {
     override val serviceClass: Class<PolarService> = PolarService::class.java
@@ -58,10 +56,7 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
 
     override val actions: List<Action>
         get() = super.actions.toMutableList().apply {
-                val uiEnabled = config.latestConfig.getBoolean(
-                    POLAR_UI_ENABLED_CONFIG,
-                    POLAR_UI_ENABLED_DEFAULT,
-                )
+                val uiEnabled = config.latestConfig.isExplicitDisclosureProject()
                 if (uiEnabled) {
                     add(
                         Action(radarService.getString(R.string.polarControlsAction), null) {

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
@@ -30,10 +30,7 @@ class PolarService : SourceService<PolarState>() {
         config: SingleRadarConfiguration
     ) {
         manager as PolarManager
-        manager.uiEnabled = config.getBoolean(
-            POLAR_UI_ENABLED_CONFIG,
-            POLAR_UI_ENABLED_DEFAULT,
-        )
+        manager.uiEnabled = config.isExplicitDisclosureProject()
     }
 
 
@@ -77,8 +74,6 @@ class PolarService : SourceService<PolarState>() {
         const val POLAR_SHARED_PREF_KEY = "polar_device_id"
         const val POLAR_COLLECTION_STARTED_KEY = "polar_collection_started"
         const val POLAR_CONNECTION_REQUESTED_KEY = "polar_connection_requested"
-        const val POLAR_UI_ENABLED_CONFIG = "polar_control_ui_enabled"
-        const val POLAR_UI_ENABLED_DEFAULT = true
     }
 }
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -107,8 +107,7 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_ID = "oauth2_client_id"
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
-        const val ENABLE_SOURCE_INFO_UI = "enable_source_info_ui"
-        const val ENABLE_DATA_COLLECTION_DISCLOSURE = "enable_data_collection_disclosure"
+        const val EXPLICIT_DISCLOSURE = "explicit_disclosure"
         const val DATA_COLLECTION_DISCLOSURE_TITLE_KEY = "data_collection_disclosure_title"
         const val DATA_COLLECTION_DISCLOSURE_BODY_KEY = "data_collection_disclosure_body"
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/config/SingleRadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/SingleRadarConfiguration.kt
@@ -129,6 +129,15 @@ class SingleRadarConfiguration(val status: RadarConfiguration.RemoteConfigStatus
         }
     }
 
+    fun isExplicitDisclosureProject(): Boolean {
+        val projectId = optString(RadarConfiguration.PROJECT_ID_KEY)?.trim()
+        if (projectId.isNullOrEmpty()) return false
+        return optString(RadarConfiguration.EXPLICIT_DISCLOSURE)
+            .orEmpty()
+            .splitToSequence(',')
+            .any { it.trim().equals(projectId, ignoreCase = true) }
+    }
+
     /** There is a non-empty configuration for given key. */
     operator fun contains(key: String): Boolean = key in config
 


### PR DESCRIPTION
The project conditional remote config was unreliable because firebase does not return the project specific values right after login. We now read a plain non conditional config and match it against the project saved in the auth state, so the disclosure, source info and Polar UI resolve correctly.