### PR TITLE
Release 1.6.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.defaults.buildfeatures.buildconfig=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-project_version=1.6.1
+project_version=1.6.5
 
 java_version=17
 kotlin_version=1.9.23

--- a/plugins/radar-android-phone-usage/src/main/java/org/radarbase/passive/phone/usage/PhoneUsageProvider.kt
+++ b/plugins/radar-android-phone-usage/src/main/java/org/radarbase/passive/phone/usage/PhoneUsageProvider.kt
@@ -21,11 +21,14 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 
 class PhoneUsageProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
 
     override val description: String
         get() = radarService.getString(R.string.phone_usage_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneUsageService> = PhoneUsageService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneBluetoothProvider.kt
@@ -21,6 +21,7 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.android.util.BluetoothStateReceiver.Companion.bluetoothPermissionList
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
@@ -28,6 +29,8 @@ import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 open class PhoneBluetoothProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_bluetooth_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneBluetoothService> = PhoneBluetoothService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneContactListProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneContactListProvider.kt
@@ -21,12 +21,15 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 
 open class PhoneContactListProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_contact_list_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneContactsListService> = PhoneContactsListService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneLocationProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneLocationProvider.kt
@@ -23,12 +23,15 @@ import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.BaseSourceState
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.MODEL
 import org.radarbase.passive.phone.PhoneSensorProvider.Companion.PRODUCER
 
 open class PhoneLocationProvider(radarService: RadarService) : SourceProvider<BaseSourceState>(radarService) {
     override val description: String
         get() = radarService.getString(R.string.phone_location_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val serviceClass: Class<PhoneLocationService> = PhoneLocationService::class.java
 

--- a/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorProvider.kt
+++ b/plugins/radar-android-phone/src/main/java/org/radarbase/passive/phone/PhoneSensorProvider.kt
@@ -19,6 +19,7 @@ package org.radarbase.passive.phone
 import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.SourceProvider
+import org.radarbase.android.source.SourceProvider.Companion.PHONE_INFO_GROUP
 
 open class PhoneSensorProvider(radarService: RadarService) : SourceProvider<PhoneState>(radarService) {
     override val serviceClass: Class<PhoneSensorService> = PhoneSensorService::class.java
@@ -32,6 +33,8 @@ open class PhoneSensorProvider(radarService: RadarService) : SourceProvider<Phon
 
     override val description: String
         get() = radarService.getString(R.string.phone_sensors_description)
+
+    override val infoGroup: String = PHONE_INFO_GROUP
 
     override val displayName: String
         get() = radarService.getString(R.string.phoneServiceDisplayName)

--- a/plugins/radar-android-polar/src/main/AndroidManifest.xml
+++ b/plugins/radar-android-polar/src/main/AndroidManifest.xml
@@ -15,5 +15,9 @@
 
     <application android:allowBackup="true">
         <service android:name=".PolarService"/>
+        <activity
+            android:name=".ui.PolarActivity"
+            android:exported="false"
+            android:label="@string/polarActivityTitle" />
     </application>
 </manifest>

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
@@ -65,6 +65,18 @@ class PolarManager(
 
         status = SourceStatusListener.Status.READY // blue loading
 
+        state.polarController = object : PolarState.PolarController {
+            override fun connectDevice() = this@PolarManager.connectDevice()
+            override fun startCollecting() = this@PolarManager.startStreaming()
+            override fun stopCollecting() = this@PolarManager.stopStreaming()
+        }
+        state.deviceName = null
+        state.isCollecting = false
+        // Restore the user's connection intent. If they connected before, reconnect automatically
+        // so the connection continues across reconnects and app restarts until they stop it.
+        val wantsConnection = service.isConnectionRequested()
+        state.connectionRequested = wantsConnection
+
         connectToPolarSDK()
 
         register()
@@ -76,6 +88,9 @@ class PolarManager(
             }
         }
 
+        if (wantsConnection) {
+            connectDevice()
+        }
     }
 
     private fun connectToPolarSDK() {
@@ -108,6 +123,7 @@ class PolarManager(
                 service.savePolarDevice(polarDeviceInfo.deviceId)
                 deviceId = polarDeviceInfo.deviceId
                 name = polarDeviceInfo.name
+                state.deviceName = polarDeviceInfo.name
 
                 if (deviceId != null) {
                     isDeviceConnected = true
@@ -123,7 +139,8 @@ class PolarManager(
             override fun deviceDisconnected(polarDeviceInfo: PolarDeviceInfo) {
                 logger.debug("Device disconnected ${polarDeviceInfo.deviceId}")
                 isDeviceConnected = false
-                disconnect()
+                state.isCollecting = false
+                status = SourceStatusListener.Status.CONNECTING
             }
 
             override fun bleSdkFeatureReady(
@@ -139,11 +156,13 @@ class PolarManager(
                             setDeviceTime(deviceId)
 
                         PolarBleApi.PolarBleSdkFeature.FEATURE_POLAR_ONLINE_STREAMING -> {
-                            streamHR()
-                            streamEcg()
-                            streamAcc()
-                            streamPpi()
-                            streamPpg()
+                            if (service.isCollectionStarted()) {
+                                logger.debug("Collection already started, resuming streams")
+                                startAllStreams()
+                                state.isCollecting = true
+                            } else {
+                                logger.debug("Collection not started by the user, waiting for an explicit start")
+                            }
                         }
 
                         else -> {
@@ -173,23 +192,27 @@ class PolarManager(
         })
 
         api.setApiLogger { s: String -> logger.debug("POLAR_API: {}", s) }
+    }
 
-        try {
-            deviceId = service.getPolarDevice()
-            if (deviceId == null) {
-                logger.debug("Searching for Polar devices")
-                connectToPolarDevice()
-            } else {
-                logger.debug("Connecting to Polar device $deviceId")
-                api.connectToDevice(deviceId!!)
+    /**
+     * Connect to the Polar device. Triggered explicitly by the user from the control screen
+     */
+    fun connectDevice() {
+        mHandler.execute {
+            if (!::api.isInitialized) {
+                logger.warn("Polar API is not set up yet, cannot connect")
+                return@execute
             }
-        } catch (a: PolarInvalidArgument) {
-            a.printStackTrace()
+            state.connectionRequested = true
+            service.setConnectionRequested(true)
+            deviceId = service.getPolarDevice()
+            connectToPolarDevice()
         }
     }
 
     override fun onClose() {
         super.onClose()
+        state.polarController = null
         if (autoConnectDisposable != null && !autoConnectDisposable!!.isDisposed) {
             autoConnectDisposable?.dispose()
         }
@@ -283,6 +306,46 @@ class PolarManager(
     private fun getTimeNano(): Double {
         val nano = (System.currentTimeMillis() * 1_000_000L).toDouble()
         return nano / 1000_000_000L
+    }
+
+    fun startStreaming() {
+        mHandler.execute {
+            service.setCollectionStarted(true)
+            if (isDeviceConnected) {
+                startAllStreams()
+                state.isCollecting = true
+            } else {
+                // Device not connected yet. Keep isCollecting false so the button stays on Start
+                // until the device connects, at which point streaming begins and it flips to Stop.
+                logger.info("Polar device not connected yet, will stream once it connects")
+            }
+        }
+    }
+
+    fun stopStreaming() {
+        mHandler.execute {
+            service.setCollectionStarted(false)
+            state.isCollecting = false
+            stopAllStreams()
+        }
+    }
+
+    private fun startAllStreams() {
+        if (hrDisposable?.isDisposed != false) streamHR()
+        if (ecgDisposable?.isDisposed != false) streamEcg()
+        if (accDisposable?.isDisposed != false) streamAcc()
+        if (ppiDisposable?.isDisposed != false) streamPpi()
+        if (ppgDisposable?.isDisposed != false) streamPpg()
+    }
+
+    private fun stopAllStreams() {
+        listOf(hrDisposable, ecgDisposable, accDisposable, ppiDisposable, ppgDisposable)
+            .forEach { if (it != null && !it.isDisposed) it.dispose() }
+        hrDisposable = null
+        ecgDisposable = null
+        accDisposable = null
+        ppiDisposable = null
+        ppgDisposable = null
     }
 
     fun streamHR() {

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
@@ -97,7 +97,7 @@ class PolarManager(
             override fun blePowerStateChanged(powered: Boolean) {
                 logger.debug("BluetoothStateChanged $powered")
                 status = if (!powered) {
-                    SourceStatusListener.Status.DISCONNECTED // red circle
+                    SourceStatusListener.Status.UNAVAILABLE
                 } else {
                     SourceStatusListener.Status.READY // blue loading
                 }

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
@@ -17,6 +17,7 @@ import org.radarbase.android.data.DataCache
 import org.radarbase.android.source.AbstractSourceManager
 import org.radarbase.android.source.SourceStatusListener
 import org.radarbase.android.util.SafeHandler
+import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 import org.radarcns.kafka.ObservationKey
 import org.radarcns.passive.polar.*
 import org.slf4j.LoggerFactory
@@ -48,6 +49,9 @@ class PolarManager(
     private var deviceId: String? = null
     private var isDeviceConnected: Boolean = false
 
+    @Volatile
+    var uiEnabled: Boolean = POLAR_UI_ENABLED_DEFAULT
+
     private var autoConnectDisposable: Disposable? = null
     private var hrDisposable: Disposable? = null
     private var ecgDisposable: Disposable? = null
@@ -65,17 +69,16 @@ class PolarManager(
 
         status = SourceStatusListener.Status.READY // blue loading
 
-        state.polarController = object : PolarState.PolarController {
-            override fun connectDevice() = this@PolarManager.connectDevice()
-            override fun startCollecting() = this@PolarManager.startStreaming()
-            override fun stopCollecting() = this@PolarManager.stopStreaming()
+        if (uiEnabled) {
+            state.polarController = object : PolarState.PolarController {
+                override fun connectDevice() = this@PolarManager.connectDevice()
+                override fun startCollecting() = this@PolarManager.startStreaming()
+                override fun stopCollecting() = this@PolarManager.stopStreaming()
+            }
+            state.deviceName = null
+            state.isCollecting = false
+            state.connectionRequested = service.isConnectionRequested()
         }
-        state.deviceName = null
-        state.isCollecting = false
-        // Restore the user's connection intent. If they connected before, reconnect automatically
-        // so the connection continues across reconnects and app restarts until they stop it.
-        val wantsConnection = service.isConnectionRequested()
-        state.connectionRequested = wantsConnection
 
         connectToPolarSDK()
 
@@ -88,8 +91,12 @@ class PolarManager(
             }
         }
 
-        if (wantsConnection) {
-            connectDevice()
+        if (uiEnabled) {
+            if (state.connectionRequested) {
+                beginConnecting()
+            }
+        } else {
+            legacyConnect()
         }
     }
 
@@ -112,7 +119,8 @@ class PolarManager(
             override fun blePowerStateChanged(powered: Boolean) {
                 logger.debug("BluetoothStateChanged $powered")
                 status = if (!powered) {
-                    SourceStatusListener.Status.UNAVAILABLE
+                    if (uiEnabled) SourceStatusListener.Status.UNAVAILABLE
+                    else SourceStatusListener.Status.DISCONNECTED
                 } else {
                     SourceStatusListener.Status.READY // blue loading
                 }
@@ -140,7 +148,11 @@ class PolarManager(
                 logger.debug("Device disconnected ${polarDeviceInfo.deviceId}")
                 isDeviceConnected = false
                 state.isCollecting = false
-                status = SourceStatusListener.Status.CONNECTING
+                if (uiEnabled) {
+                    status = SourceStatusListener.Status.CONNECTING
+                } else {
+                    disconnect()
+                }
             }
 
             override fun bleSdkFeatureReady(
@@ -156,8 +168,8 @@ class PolarManager(
                             setDeviceTime(deviceId)
 
                         PolarBleApi.PolarBleSdkFeature.FEATURE_POLAR_ONLINE_STREAMING -> {
-                            if (service.isCollectionStarted()) {
-                                logger.debug("Collection already started, resuming streams")
+                            if (!uiEnabled || service.isCollectionStarted()) {
+                                logger.debug("Starting Polar streams, uiEnabled={}", uiEnabled)
                                 startAllStreams()
                                 state.isCollecting = true
                             } else {
@@ -194,19 +206,36 @@ class PolarManager(
         api.setApiLogger { s: String -> logger.debug("POLAR_API: {}", s) }
     }
 
-    /**
-     * Connect to the Polar device. Triggered explicitly by the user from the control screen
-     */
     fun connectDevice() {
+        service.setConnectionRequested(true)
+        beginConnecting()
+    }
+
+    /** Start (or resume) connecting without changing the saved connection intent. */
+    private fun beginConnecting() {
         mHandler.execute {
             if (!::api.isInitialized) {
                 logger.warn("Polar API is not set up yet, cannot connect")
                 return@execute
             }
             state.connectionRequested = true
-            service.setConnectionRequested(true)
             deviceId = service.getPolarDevice()
             connectToPolarDevice()
+        }
+    }
+
+    private fun legacyConnect() {
+        try {
+            deviceId = service.getPolarDevice()
+            if (deviceId == null) {
+                logger.debug("Searching for Polar devices")
+                connectToPolarDevice()
+            } else {
+                logger.debug("Connecting to Polar device $deviceId")
+                api.connectToDevice(deviceId!!)
+            }
+        } catch (a: PolarInvalidArgument) {
+            a.printStackTrace()
         }
     }
 

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarManager.kt
@@ -17,7 +17,6 @@ import org.radarbase.android.data.DataCache
 import org.radarbase.android.source.AbstractSourceManager
 import org.radarbase.android.source.SourceStatusListener
 import org.radarbase.android.util.SafeHandler
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 import org.radarcns.kafka.ObservationKey
 import org.radarcns.passive.polar.*
 import org.slf4j.LoggerFactory
@@ -50,7 +49,7 @@ class PolarManager(
     private var isDeviceConnected: Boolean = false
 
     @Volatile
-    var uiEnabled: Boolean = POLAR_UI_ENABLED_DEFAULT
+    var uiEnabled: Boolean = false
 
     private var autoConnectDisposable: Disposable? = null
     private var hrDisposable: Disposable? = null

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -47,9 +47,9 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
 
     override val featuresNeeded = listOf(PackageManager.FEATURE_BLUETOOTH, PackageManager.FEATURE_BLUETOOTH_LE)
 
-    override val sourceProducer: String = PRODUCER
+    override val sourceProducer: String = POLAR_PRODUCER
 
-    override val sourceModel: String = MODEL
+    override val sourceModel: String = POLAR_MODEL
 
     override val version: String = BuildConfig.VERSION_NAME
 
@@ -73,7 +73,7 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
 
     override val isFilterable = true
     companion object {
-        const val PRODUCER = "Polar"
-        const val MODEL = "Generic"
+        private const val POLAR_PRODUCER = "Polar"
+        private const val POLAR_MODEL = "Generic"
     }
 }

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -2,6 +2,7 @@ package org.radarbase.passive.polar
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import org.radarbase.android.BuildConfig
@@ -9,6 +10,7 @@ import org.radarbase.android.RadarService
 import org.radarbase.android.source.SourceProvider
 import org.radarbase.passive.polar.PolarService.Companion.SHARED_PREF_KEY
 import org.radarbase.passive.polar.PolarService.Companion.SHARED_PREF_NAME
+import org.radarbase.passive.polar.ui.PolarActivity
 
 open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState>(radarService) {
     override val serviceClass: Class<PolarService> = PolarService::class.java
@@ -53,14 +55,21 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
 
     override val actions: List<Action>
         get() =
-            super.actions.toMutableList().apply { add(
-                Action("Reset Polar device ID", null) {
-                    applicationContext.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE)
-                        .edit()
-                        .remove(SHARED_PREF_KEY)
-                        .apply()
-                }
-            )}.toList()
+            super.actions.toMutableList().apply {
+                add(
+                    Action(radarService.getString(R.string.polarControlsAction), null) {
+                        startActivity(Intent(this, PolarActivity::class.java))
+                    }
+                )
+                add(
+                    Action("Reset Polar device ID", null) {
+                        applicationContext.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE)
+                            .edit()
+                            .remove(SHARED_PREF_KEY)
+                            .apply()
+                    }
+                )
+            }.toList()
 
     override val isFilterable = true
     companion object {

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -12,8 +12,6 @@ import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_KEY
 import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_NAME
 import org.radarbase.passive.polar.ui.PolarActivity
 import androidx.core.content.edit
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_CONFIG
-import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 
 open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState>(radarService) {
     override val serviceClass: Class<PolarService> = PolarService::class.java
@@ -58,10 +56,7 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
 
     override val actions: List<Action>
         get() = super.actions.toMutableList().apply {
-                val uiEnabled = config.latestConfig.getBoolean(
-                    POLAR_UI_ENABLED_CONFIG,
-                    POLAR_UI_ENABLED_DEFAULT,
-                )
+                val uiEnabled = config.latestConfig.isExplicitDisclosureProject()
                 if (uiEnabled) {
                     add(
                         Action(radarService.getString(R.string.polarControlsAction), null) {

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -12,6 +12,8 @@ import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_KEY
 import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_NAME
 import org.radarbase.passive.polar.ui.PolarActivity
 import androidx.core.content.edit
+import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_CONFIG
+import org.radarbase.passive.polar.PolarService.Companion.POLAR_UI_ENABLED_DEFAULT
 
 open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState>(radarService) {
     override val serviceClass: Class<PolarService> = PolarService::class.java
@@ -55,13 +57,18 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
     override val version: String = BuildConfig.VERSION_NAME
 
     override val actions: List<Action>
-        get() =
-            super.actions.toMutableList().apply {
-                add(
-                    Action(radarService.getString(R.string.polarControlsAction), null) {
-                        startActivity(Intent(this, PolarActivity::class.java))
-                    }
+        get() = super.actions.toMutableList().apply {
+                val uiEnabled = config.latestConfig.getBoolean(
+                    POLAR_UI_ENABLED_CONFIG,
+                    POLAR_UI_ENABLED_DEFAULT,
                 )
+                if (uiEnabled) {
+                    add(
+                        Action(radarService.getString(R.string.polarControlsAction), null) {
+                            startActivity(Intent(this, PolarActivity::class.java))
+                        }
+                    )
+                }
                 add(
                     Action("Reset Polar device ID", null) {
                         applicationContext.getSharedPreferences(POLAR_SHARED_PREF_NAME, Context.MODE_PRIVATE)

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarProvider.kt
@@ -8,9 +8,10 @@ import android.os.Build
 import org.radarbase.android.BuildConfig
 import org.radarbase.android.RadarService
 import org.radarbase.android.source.SourceProvider
-import org.radarbase.passive.polar.PolarService.Companion.SHARED_PREF_KEY
-import org.radarbase.passive.polar.PolarService.Companion.SHARED_PREF_NAME
+import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_KEY
+import org.radarbase.passive.polar.PolarService.Companion.POLAR_SHARED_PREF_NAME
 import org.radarbase.passive.polar.ui.PolarActivity
+import androidx.core.content.edit
 
 open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState>(radarService) {
     override val serviceClass: Class<PolarService> = PolarService::class.java
@@ -63,10 +64,10 @@ open class PolarProvider(radarService: RadarService) : SourceProvider<PolarState
                 )
                 add(
                     Action("Reset Polar device ID", null) {
-                        applicationContext.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE)
-                            .edit()
-                            .remove(SHARED_PREF_KEY)
-                            .apply()
+                        applicationContext.getSharedPreferences(POLAR_SHARED_PREF_NAME, Context.MODE_PRIVATE)
+                            .edit {
+                                remove(POLAR_SHARED_PREF_KEY)
+                            }
                     }
                 )
             }.toList()

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import org.radarbase.android.config.SingleRadarConfiguration
 import org.radarbase.android.source.SourceManager
 import org.radarbase.android.source.SourceService
+import androidx.core.content.edit
 
 /**
  * A service that manages the Polar manager and a TableDataHandler to send store the data of
@@ -19,7 +20,7 @@ class PolarService : SourceService<PolarState>() {
 
     override fun onCreate() {
         super.onCreate()
-        sharedPreferences = getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE)
+        sharedPreferences = getSharedPreferences(POLAR_SHARED_PREF_NAME, Context.MODE_PRIVATE)
     }
 
     override fun createSourceManager() = PolarManager(this)
@@ -34,17 +35,44 @@ class PolarService : SourceService<PolarState>() {
 
     fun savePolarDevice(deviceId: String) =
         sharedPreferences
-            .edit()
-            .putString(SHARED_PREF_KEY, deviceId)
-            .apply()
+            .edit {
+                putString(POLAR_SHARED_PREF_KEY, deviceId)
+            }
 
     fun getPolarDevice(): String? =
         sharedPreferences
-            .getString(SHARED_PREF_KEY, null)
+            .getString(POLAR_SHARED_PREF_KEY, null)
+
+    /** Persist whether the user has started data collection, so it survives reconnects and restarts. */
+    fun setCollectionStarted(started: Boolean) =
+        sharedPreferences
+            .edit {
+                putBoolean(POLAR_COLLECTION_STARTED_KEY, started)
+            }
+
+    fun isCollectionStarted(): Boolean =
+        sharedPreferences
+            .getBoolean(POLAR_COLLECTION_STARTED_KEY, false)
+
+    /**
+     * Persist whether the user has asked to connect the device. Once set, the manager auto-connects
+     * on every start, so the connection continues across reconnects and app restarts until cleared.
+     */
+    fun setConnectionRequested(requested: Boolean) =
+        sharedPreferences
+            .edit {
+                putBoolean(POLAR_CONNECTION_REQUESTED_KEY, requested)
+            }
+
+    fun isConnectionRequested(): Boolean =
+        sharedPreferences
+            .getBoolean(POLAR_CONNECTION_REQUESTED_KEY, false)
 
     companion object {
-        val SHARED_PREF_NAME: String = PolarService::class.java.name
-        const val SHARED_PREF_KEY = "polar_device_id"
+        val POLAR_SHARED_PREF_NAME: String = PolarService::class.java.name
+        const val POLAR_SHARED_PREF_KEY = "polar_device_id"
+        const val POLAR_COLLECTION_STARTED_KEY = "polar_collection_started"
+        const val POLAR_CONNECTION_REQUESTED_KEY = "polar_connection_requested"
     }
 }
 

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
@@ -30,10 +30,7 @@ class PolarService : SourceService<PolarState>() {
         config: SingleRadarConfiguration
     ) {
         manager as PolarManager
-        manager.uiEnabled = config.getBoolean(
-            POLAR_UI_ENABLED_CONFIG,
-            POLAR_UI_ENABLED_DEFAULT,
-        )
+        manager.uiEnabled = config.isExplicitDisclosureProject()
     }
 
 
@@ -77,8 +74,6 @@ class PolarService : SourceService<PolarState>() {
         const val POLAR_SHARED_PREF_KEY = "polar_device_id"
         const val POLAR_COLLECTION_STARTED_KEY = "polar_collection_started"
         const val POLAR_CONNECTION_REQUESTED_KEY = "polar_connection_requested"
-        const val POLAR_UI_ENABLED_CONFIG = "polar_control_ui_enabled"
-        const val POLAR_UI_ENABLED_DEFAULT = true
     }
 }
 

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarService.kt
@@ -30,6 +30,10 @@ class PolarService : SourceService<PolarState>() {
         config: SingleRadarConfiguration
     ) {
         manager as PolarManager
+        manager.uiEnabled = config.getBoolean(
+            POLAR_UI_ENABLED_CONFIG,
+            POLAR_UI_ENABLED_DEFAULT,
+        )
     }
 
 
@@ -73,6 +77,8 @@ class PolarService : SourceService<PolarState>() {
         const val POLAR_SHARED_PREF_KEY = "polar_device_id"
         const val POLAR_COLLECTION_STARTED_KEY = "polar_collection_started"
         const val POLAR_CONNECTION_REQUESTED_KEY = "polar_connection_requested"
+        const val POLAR_UI_ENABLED_CONFIG = "polar_control_ui_enabled"
+        const val POLAR_UI_ENABLED_DEFAULT = true
     }
 }
 

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarState.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/PolarState.kt
@@ -2,9 +2,6 @@ package org.radarbase.passive.polar
 
 import org.radarbase.android.source.BaseSourceState
 
-/**
- * The status on a single point in time
- */
 class PolarState : BaseSourceState() {
     override val acceleration = floatArrayOf(Float.NaN, Float.NaN, Float.NaN)
     @set:Synchronized
@@ -12,10 +9,34 @@ class PolarState : BaseSourceState() {
 
     override val hasAcceleration: Boolean = true
 
+    @Volatile
+    var deviceName: String? = null
+
+    /**
+     * Whether data is actively streaming.
+     */
+    @Volatile
+    var isCollecting: Boolean = false
+
+    /**
+     * Whether the user has asked to connect (tapped Connect).
+     */
+    @Volatile
+    var connectionRequested: Boolean = false
+
+    @Volatile
+    var polarController: PolarController? = null
+
     @Synchronized
     fun setAcceleration(x: Float, y: Float, z: Float) {
         this.acceleration[0] = x
         this.acceleration[1] = y
         this.acceleration[2] = z
+    }
+
+    interface PolarController {
+        fun connectDevice()
+        fun startCollecting()
+        fun stopCollecting()
     }
 }

--- a/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/ui/PolarActivity.kt
+++ b/plugins/radar-android-polar/src/main/java/org/radarbase/passive/polar/ui/PolarActivity.kt
@@ -1,0 +1,209 @@
+package org.radarbase.passive.polar.ui
+
+import android.bluetooth.BluetoothManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.provider.Settings
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import org.radarbase.android.IRadarBinder
+import org.radarbase.android.RadarApplication.Companion.radarApp
+import org.radarbase.android.source.SourceStatusListener
+import org.radarbase.passive.polar.PolarProvider
+import org.radarbase.passive.polar.PolarState
+import org.radarbase.passive.polar.R
+import org.slf4j.LoggerFactory
+
+/**
+ * Explicit control screen for the Polar device.
+ */
+class PolarActivity : AppCompatActivity() {
+
+    private enum class Action { ENABLE_BLUETOOTH, CONNECT, START, STOP, NONE }
+
+    private var provider: PolarProvider? = null
+    private val state: PolarState?
+        get() = provider?.connection?.sourceState
+
+    private lateinit var deviceNameText: TextView
+    private lateinit var statusText: TextView
+    private lateinit var bluetoothIcon: ImageView
+    private lateinit var messageText: TextView
+    private lateinit var primaryButton: Button
+
+    private var currentAction: Action = Action.NONE
+    private var wasConnected: Boolean = false
+    private var connectionStateKnown: Boolean = false
+
+    private val uiHandler = Handler(Looper.getMainLooper())
+    private val refreshRunnable = object : Runnable {
+        override fun run() {
+            render()
+            uiHandler.postDelayed(this, REFRESH_INTERVAL_MS)
+        }
+    }
+
+    private val radarServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+            val binder = service as? IRadarBinder ?: return
+            provider = binder.connections.filterIsInstance<PolarProvider>().firstOrNull()
+            render()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            provider = null
+            render()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_polar)
+
+        deviceNameText = findViewById(R.id.polar_device_name)
+        statusText = findViewById(R.id.polar_status_text)
+        bluetoothIcon = findViewById(R.id.polar_bluetooth_icon)
+        messageText = findViewById(R.id.polar_message)
+        primaryButton = findViewById(R.id.polar_primary_button)
+
+        primaryButton.setOnClickListener { onPrimaryClicked() }
+        render()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        bindService(Intent(this, radarApp.radarService), radarServiceConnection, 0)
+        uiHandler.post(refreshRunnable)
+    }
+
+    override fun onStop() {
+        uiHandler.removeCallbacks(refreshRunnable)
+        try {
+            unbindService(radarServiceConnection)
+        } catch (ex: IllegalArgumentException) {
+            logger.warn("Polar control screen was not bound to the service")
+        }
+        super.onStop()
+    }
+
+    private fun onPrimaryClicked() {
+        when (currentAction) {
+            Action.ENABLE_BLUETOOTH -> openBluetoothSettings()
+            Action.CONNECT -> {
+                logger.debug("User requested to connect the Polar device")
+                state?.polarController?.connectDevice()
+            }
+            Action.START -> {
+                logger.debug("User requested to start Polar collection")
+                state?.polarController?.startCollecting()
+            }
+            Action.STOP -> {
+                logger.debug("User requested to stop Polar collection")
+                state?.polarController?.stopCollecting()
+            }
+            Action.NONE -> { /* button is disabled in this state */ }
+        }
+        render()
+    }
+
+    private fun isBluetoothOn(): Boolean {
+        val manager = getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        return manager?.adapter?.isEnabled == true
+    }
+
+    private fun render() {
+        if (!isBluetoothOn()) {
+            wasConnected = false
+            connectionStateKnown = false
+            deviceNameText.text = state?.deviceName ?: getString(R.string.polarNoDevice)
+            statusText.text = getString(R.string.polarStatusBluetoothOff)
+            bluetoothIcon.alpha = 0.3f
+            messageText.visibility = View.VISIBLE
+            messageText.text = getString(R.string.polarBluetoothOffMessage)
+            primaryButton.text = getString(R.string.polarTurnOnBluetooth)
+            primaryButton.isEnabled = true
+            currentAction = Action.ENABLE_BLUETOOTH
+            return
+        }
+
+        val st = state
+        val controller = st?.polarController
+        val status = st?.status ?: SourceStatusListener.Status.DISCONNECTED
+        val collecting = st?.isCollecting ?: false
+        val connectionRequested = st?.connectionRequested ?: false
+        val connected = status == SourceStatusListener.Status.CONNECTED
+
+        deviceNameText.text = st?.deviceName ?: getString(R.string.polarNoDevice)
+        bluetoothIcon.alpha = if (connected) 1.0f else 0.6f
+        messageText.visibility = View.GONE
+
+        if (st != null) {
+            if (connectionStateKnown && connected && !wasConnected) {
+                Toast.makeText(this, R.string.polarDeviceConnectedToast, Toast.LENGTH_SHORT).show()
+            }
+            wasConnected = connected
+            connectionStateKnown = true
+        }
+
+        when {
+            controller == null -> {
+                statusText.text = getString(R.string.polarStatusNotConnected)
+                primaryButton.text = getString(R.string.polarConnectDevice)
+                primaryButton.isEnabled = false
+                currentAction = Action.NONE
+            }
+            collecting -> {
+                statusText.text = getString(R.string.polarStatusConnected)
+                primaryButton.text = getString(R.string.polarStopCollection)
+                primaryButton.isEnabled = true
+                currentAction = Action.STOP
+            }
+            connected -> {
+                statusText.text = getString(R.string.polarStatusConnected)
+                primaryButton.text = getString(R.string.polarStartCollection)
+                primaryButton.isEnabled = true
+                currentAction = Action.START
+            }
+            connectionRequested -> {
+                statusText.text = getString(R.string.polarStatusConnecting)
+                primaryButton.text = getString(R.string.polarStatusConnecting)
+                primaryButton.isEnabled = false
+                currentAction = Action.NONE
+            }
+            else -> {
+                statusText.text = getString(R.string.polarStatusNotConnected)
+                primaryButton.text = getString(R.string.polarConnectDevice)
+                primaryButton.isEnabled = true
+                currentAction = Action.CONNECT
+            }
+        }
+    }
+
+    private fun openBluetoothSettings() {
+        try {
+            startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
+        } catch (ex: Exception) {
+            logger.warn("Could not open Bluetooth settings, falling back to general settings", ex)
+            try {
+                startActivity(Intent(Settings.ACTION_SETTINGS))
+            } catch (ignored: Exception) {
+                logger.error("Could not open settings to enable Bluetooth")
+            }
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(PolarActivity::class.java)
+        private const val REFRESH_INTERVAL_MS = 800L
+    }
+}

--- a/plugins/radar-android-polar/src/main/res/drawable/ic_polar_bluetooth.xml
+++ b/plugins/radar-android-polar/src/main/res/drawable/ic_polar_bluetooth.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41V22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59V5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z" />
+</vector>

--- a/plugins/radar-android-polar/src/main/res/layout/activity_polar.xml
+++ b/plugins/radar-android-polar/src/main/res/layout/activity_polar.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/polar_device_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:text="@string/polarNoDevice"
+        android:textColor="?attr/colorPrimary"
+        android:textSize="22sp"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/polar_bluetooth_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="8dp"
+            android:alpha="0.3"
+            android:contentDescription="@string/polarBluetoothDescription"
+            android:src="@drawable/ic_polar_bluetooth"
+            android:tint="?attr/colorPrimary" />
+
+        <TextView
+            android:id="@+id/polar_status_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/polarStatusNotConnected"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/polar_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:gravity="center"
+        android:text="@string/polarBluetoothOffMessage"
+        android:textSize="15sp"
+        android:visibility="gone" />
+
+    <Button
+        android:id="@+id/polar_primary_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:text="@string/polarConnectDevice" />
+
+</LinearLayout>

--- a/plugins/radar-android-polar/src/main/res/layout/activity_polar.xml
+++ b/plugins/radar-android-polar/src/main/res/layout/activity_polar.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -31,7 +32,7 @@
             android:alpha="0.3"
             android:contentDescription="@string/polarBluetoothDescription"
             android:src="@drawable/ic_polar_bluetooth"
-            android:tint="?attr/colorPrimary" />
+            app:tint="?attr/colorPrimary" />
 
         <TextView
             android:id="@+id/polar_status_text"

--- a/plugins/radar-android-polar/src/main/res/values/strings.xml
+++ b/plugins/radar-android-polar/src/main/res/values/strings.xml
@@ -2,4 +2,21 @@
     <string name="polarDisplayName">Polar auto</string>
     <string name="polarDeviceName">Polar auto %1$s</string>
     <string name="polarSensorsDescription">Polar sensors like acceleration and step counts.</string>
+
+    <string name="polarControlsAction">Polar device</string>
+    <string name="polarActivityTitle">Polar device</string>
+    <string name="polarNoDevice">No Polar device</string>
+
+    <string name="polarStatusConnected">Connected</string>
+    <string name="polarStatusConnecting">Connecting…</string>
+    <string name="polarStatusNotConnected">Not connected</string>
+    <string name="polarStatusBluetoothOff">Bluetooth is off</string>
+
+    <string name="polarBluetoothOffMessage">Bluetooth is off. Please turn it on to connect your Polar device.</string>
+    <string name="polarTurnOnBluetooth">Turn on Bluetooth</string>
+    <string name="polarConnectDevice">Connect device</string>
+    <string name="polarStartCollection">Start data collection</string>
+    <string name="polarStopCollection">Stop data collection</string>
+    <string name="polarDeviceConnectedToast">Device connected</string>
+    <string name="polarBluetoothDescription">Bluetooth connection status</string>
 </resources>

--- a/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/IRadarBinder.kt
@@ -43,4 +43,6 @@ interface IRadarBinder : IBinder {
     fun stopScanning()
 
     fun needsBluetooth(): Boolean
+
+    fun checkPermissions()
 }

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -16,8 +16,21 @@
 
 package org.radarbase.android
 
+import android.Manifest.permission.ACCESS_COARSE_LOCATION
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.Manifest.permission.ACTIVITY_RECOGNITION
+import android.Manifest.permission.BLUETOOTH_ADVERTISE
+import android.Manifest.permission.BLUETOOTH_CONNECT
+import android.Manifest.permission.BLUETOOTH_SCAN
+import android.Manifest.permission.BODY_SENSORS
+import android.Manifest.permission.RECORD_AUDIO
+import android.Manifest.permission.UWB_RANGING
 import android.content.Context
 import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.Q
+import android.os.Build.VERSION_CODES.S
+import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Bundle
 import android.os.Process
 import androidx.annotation.CallSuper
@@ -37,6 +50,7 @@ import org.radarbase.android.RadarService.Companion.EXTRA_PERMISSIONS
 import org.radarbase.android.auth.AuthService
 import org.radarbase.android.config.CombinedRadarConfig
 import org.radarbase.android.util.*
+import org.radarbase.android.util.PermissionHandler.Companion.isPermissionGranted
 import org.slf4j.LoggerFactory
 
 /** Base MainActivity class. It manages the services to collect the data and starts up a view. To
@@ -165,15 +179,8 @@ abstract class MainActivity : AppCompatActivity() {
         authConnection.bind()
         bluetoothEnforcer.start()
 
-        val radarServiceCls = radarApp.radarService
-        try {
-            val intent = Intent(this, radarServiceCls)
-            ContextCompat.startForegroundService(this, intent)
-        } catch (ex: IllegalStateException) {
-            logger.error("Failed to start RadarService: activity is in background.", ex)
-        }
-
         radarConnection.bind()
+        maybeStartRadarServiceAsForeground()
 
         permissionHandler.invalidateCache()
 
@@ -217,6 +224,7 @@ abstract class MainActivity : AppCompatActivity() {
         }
         bluetoothEnforcer.onActivityResult(requestCode, resultCode)
         permissionHandler.onActivityResult(requestCode, resultCode)
+        maybeStartRadarServiceAsForeground()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
@@ -225,6 +233,34 @@ abstract class MainActivity : AppCompatActivity() {
             mHandler.start()
         }
         permissionHandler.permissionsGranted(requestCode, permissions, grantResults)
+        maybeStartRadarServiceAsForeground()
+    }
+
+    private fun maybeStartRadarServiceAsForeground() {
+        if (SDK_INT >= UPSIDE_DOWN_CAKE && !hasAnyTypedFgsPermission()) {
+            return
+        }
+        try {
+            val intent = Intent(this, radarApp.radarService)
+            ContextCompat.startForegroundService(this, intent)
+        } catch (ex: IllegalStateException) {
+            logger.error("Failed to start RadarService: activity is in background.", ex)
+        }
+    }
+
+    private fun hasAnyTypedFgsPermission(): Boolean {
+        if (isPermissionGranted(ACCESS_COARSE_LOCATION)) return true
+        if (isPermissionGranted(ACCESS_FINE_LOCATION)) return true
+        if (isPermissionGranted(RECORD_AUDIO)) return true
+        if (SDK_INT >= Q && isPermissionGranted(ACTIVITY_RECOGNITION)) return true
+        if (isPermissionGranted(BODY_SENSORS)) return true
+        if (SDK_INT >= S) {
+            if (isPermissionGranted(BLUETOOTH_CONNECT)) return true
+            if (isPermissionGranted(BLUETOOTH_SCAN)) return true
+            if (isPermissionGranted(BLUETOOTH_ADVERTISE)) return true
+            if (isPermissionGranted(UWB_RANGING)) return true
+        }
+        return false
     }
 
     /**

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -107,6 +107,7 @@ abstract class MainActivity : AppCompatActivity() {
 
         radarConnection = ManagedServiceConnection<IRadarBinder>(this@MainActivity, radarApp.radarService).apply {
             bindFlags = Context.BIND_ABOVE_CLIENT or Context.BIND_AUTO_CREATE
+            onBoundListeners += IRadarBinder::checkPermissions
             onBoundListeners += IRadarBinder::startScanning
             onBoundListeners += { binder -> view?.onRadarServiceBound(binder) }
             onUnboundListeners += IRadarBinder::stopScanning

--- a/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/MainActivity.kt
@@ -138,7 +138,6 @@ abstract class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        permissionHandler.onActivityResumed()
         uiUpdater = mHandler.repeat(uiRefreshRate) {
             try {
                 // Update all rows in the UI with the data from the connections
@@ -160,7 +159,9 @@ abstract class MainActivity : AppCompatActivity() {
     @CallSuper
     public override fun onStart() {
         super.onStart()
-        mHandler.start()
+        if (!mHandler.isStarted) {
+            mHandler.start()
+        }
         authConnection.bind()
         bluetoothEnforcer.start()
 
@@ -211,12 +212,18 @@ abstract class MainActivity : AppCompatActivity() {
 
     public override fun onActivityResult(requestCode: Int, resultCode: Int, result: Intent?) {
         super.onActivityResult(requestCode, resultCode, result)
+        if (!mHandler.isStarted) {
+            mHandler.start()
+        }
         bluetoothEnforcer.onActivityResult(requestCode, resultCode)
         permissionHandler.onActivityResult(requestCode, resultCode)
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (!mHandler.isStarted) {
+            mHandler.start()
+        }
         permissionHandler.permissionsGranted(requestCode, permissions, grantResults)
     }
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -108,6 +108,9 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
         const val ENABLE_SOURCE_INFO_UI = "enable_source_info_ui"
+        const val ENABLE_DATA_COLLECTION_DISCLOSURE = "enable_data_collection_disclosure"
+        const val DATA_COLLECTION_DISCLOSURE_TITLE_KEY = "data_collection_disclosure_title"
+        const val DATA_COLLECTION_DISCLOSURE_BODY_KEY = "data_collection_disclosure_body"
 
         const val BG_LOCATION_DISCLOSURE_TITLE_KEY = "bg_location_disclosure_title"
         const val BG_LOCATION_DISCLOSURE_BODY_KEY = "bg_location_disclosure_body"

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -107,6 +107,7 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_ID = "oauth2_client_id"
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
+        const val ENABLE_SOURCE_INFO_UI = "enable_source_info_ui"
 
         const val BG_LOCATION_DISCLOSURE_TITLE_KEY = "bg_location_disclosure_title"
         const val BG_LOCATION_DISCLOSURE_BODY_KEY = "bg_location_disclosure_body"

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarConfiguration.kt
@@ -107,8 +107,7 @@ interface RadarConfiguration {
         const val OAUTH2_CLIENT_ID = "oauth2_client_id"
         const val OAUTH2_CLIENT_SECRET = "oauth2_client_secret"
         const val ENABLE_BLUETOOTH_REQUESTS = "enable_bluetooth_requests"
-        const val ENABLE_SOURCE_INFO_UI = "enable_source_info_ui"
-        const val ENABLE_DATA_COLLECTION_DISCLOSURE = "enable_data_collection_disclosure"
+        const val EXPLICIT_DISCLOSURE = "explicit_disclosure"
         const val DATA_COLLECTION_DISCLOSURE_TITLE_KEY = "data_collection_disclosure_title"
         const val DATA_COLLECTION_DISCLOSURE_BODY_KEY = "data_collection_disclosure_body"
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -27,7 +27,6 @@ import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.*
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -235,18 +234,33 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             // Below API 34: Start foreground without service types
             startForeground(1, createForegroundNotification())
         } else {
-
-            /**
-             * API 34+ (Android 14+): Adding DATA_SYNC type
-             * Currently this is not explicitly checking for android 14+ version.
-             * This need to be modified it in future when setting new targetSdkVersion
-             */
-            startForeground(1, createForegroundNotification(),
-                        FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-            )
+            val grantedTyped = currentlyGrantedTypedFgsPermissions()
+            if (grantedTyped.isEmpty()) {
+                logger.warn("startForegroundService called without any typed FGS permission, stopping to avoid the 5s deadline")
+                stopSelf(startId)
+                return START_NOT_STICKY
+            }
+            startForegroundIfNeeded(grantedTyped)
         }
 
         return START_STICKY
+    }
+
+    private fun currentlyGrantedTypedFgsPermissions(): Set<String> = buildSet {
+        fun maybeAdd(permission: String) {
+            if (isPermissionGranted(permission)) add(permission)
+        }
+        maybeAdd(ACCESS_COARSE_LOCATION)
+        maybeAdd(ACCESS_FINE_LOCATION)
+        maybeAdd(RECORD_AUDIO)
+        if (SDK_INT >= Q) maybeAdd(ACTIVITY_RECOGNITION)
+        maybeAdd(BODY_SENSORS)
+        if (SDK_INT >= S) {
+            maybeAdd(BLUETOOTH_CONNECT)
+            maybeAdd(BLUETOOTH_SCAN)
+            maybeAdd(BLUETOOTH_ADVERTISE)
+            maybeAdd(UWB_RANGING)
+        }
     }
 
     private fun startForegroundIfNeeded(grantedPermissions: Set<String>) {
@@ -277,10 +291,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
 
         if (fgsTypePermissions.isNotEmpty()) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
-
             val combinedFgsType: Int = fgsTypePermissions.reduce { acc, type -> acc or type }
-
             startForeground(
                 1, createForegroundNotification(),
                 combinedFgsType
@@ -392,7 +403,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         }
 
         if (grantedPermissions.isNotEmpty()) {
-            startForegroundIfNeeded(grantedPermissions)
+            startForegroundIfNeeded(currentlyGrantedTypedFgsPermissions())
             mHandler.execute {
                 logger.info("Granted permissions {}", grantedPermissions)
                 // Permission granted.

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -381,12 +381,13 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
     }
 
     private fun requestPermissions(permissions: Collection<String>) {
+        val permissionArray = permissions.toTypedArray()
         mainHandler.post {
             startActivity(Intent(this, radarApp.mainActivity).apply {
                 action = ACTION_CHECK_PERMISSIONS
                 addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                putExtra(EXTRA_PERMISSIONS, permissions.toTypedArray())
+                putExtra(EXTRA_PERMISSIONS, permissionArray)
             })
         }
     }

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -702,6 +702,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
         override fun startScanning() = this@RadarService.startActiveScanning()
         override fun stopScanning() = this@RadarService.stopActiveScanning()
 
+        override fun checkPermissions() = this@RadarService.checkPermissions()
+
         override val serverStatus: ServerStatusListener.Status
             get() = this@RadarService.serverStatus
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/RadarService.kt
@@ -24,9 +24,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
 import android.os.*
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
@@ -129,16 +127,11 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
 
     private var bluetoothNotification: NotificationHandler.NotificationRegistration? = null
 
-    @RequiresApi(Q)
-    val fgsHealthPermissions: Set<String> = setOf(BODY_SENSORS, ACTIVITY_RECOGNITION)
     @RequiresApi(S)
     val fgsConnectDevicePermissions: Set<String> =
         setOf(BLUETOOTH_CONNECT, BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE, UWB_RANGING)
     private val fgsLocationPermissions: Set<String> =
         setOf(ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION)
-    private val fgsMicrophonePermissions: Set<String> =
-        setOf(RECORD_AUDIO)
-
 
     /** Defines callbacks for service binding, passed to bindService()  */
     private lateinit var bluetoothReceiver: BluetoothStateReceiver
@@ -274,20 +267,8 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
             }
         }
 
-        if (grantedPermissions.intersect(fgsHealthPermissions)
-                .isNotEmpty() && (SDK_INT >= UPSIDE_DOWN_CAKE)
-        ) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_HEALTH)
-        }
-
         if (grantedPermissions.intersect(fgsLocationPermissions).isNotEmpty()) {
             fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_LOCATION)
-        }
-
-        if (grantedPermissions.intersect(fgsMicrophonePermissions)
-                .isNotEmpty() && (SDK_INT >= VERSION_CODES.R)
-        ) {
-            fgsTypePermissions.add(FOREGROUND_SERVICE_TYPE_MICROPHONE)
         }
 
         if (fgsTypePermissions.isNotEmpty()) {
@@ -777,7 +758,7 @@ abstract class RadarService : LifecycleService(), ServerStatusListener, LoginLis
 
         private const val BLUETOOTH_NOTIFICATION = 521290
 
-        val ACCESS_BACKGROUND_LOCATION_COMPAT = if (SDK_INT >= VERSION_CODES.Q)
+        val ACCESS_BACKGROUND_LOCATION_COMPAT = if (SDK_INT >= Q)
             ACCESS_BACKGROUND_LOCATION else "android.permission.ACCESS_BACKGROUND_LOCATION"
 
         private const val BACKGROUND_REQUEST_CODE = 9559

--- a/radar-commons-android/src/main/java/org/radarbase/android/config/SingleRadarConfiguration.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/config/SingleRadarConfiguration.kt
@@ -129,6 +129,15 @@ class SingleRadarConfiguration(val status: RadarConfiguration.RemoteConfigStatus
         }
     }
 
+    fun isExplicitDisclosureProject(): Boolean {
+        val projectId = optString(RadarConfiguration.PROJECT_ID_KEY)?.trim()
+        if (projectId.isNullOrEmpty()) return false
+        return optString(RadarConfiguration.EXPLICIT_DISCLOSURE)
+            .orEmpty()
+            .splitToSequence(',')
+            .any { it.trim().equals(projectId, ignoreCase = true) }
+    }
+
     /** There is a non-empty configuration for given key. */
     operator fun contains(key: String): Boolean = key in config
 

--- a/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/source/SourceProvider.kt
@@ -200,6 +200,14 @@ abstract class SourceProvider<T : BaseSourceState>(protected val radarService: R
     open val isDisplayable: Boolean = true
 
     /**
+     * Identifier that groups several providers together. Providers that
+     * share a non-null [infoGroup] describe a single displayed row collectively, so opening the info
+     * view of the one visible provider can list every grouped provider's [displayName] and
+     * [description]. Defaults to null, meaning the provider stands on its own.
+     */
+    open val infoGroup: String? = null
+
+    /**
      * Whether the source name should be checked with given filters before a connection is allowed
      */
     open val isFilterable: Boolean = false
@@ -253,6 +261,12 @@ abstract class SourceProvider<T : BaseSourceState>(protected val radarService: R
         const val PLUGIN_NAME_KEY = "org.radarbase.android.source.SourceProvider.pluginName"
         const val PRODUCER_KEY = "org.radarbase.android.source.SourceProvider.sourceProducer"
         const val MODEL_KEY = "org.radarbase.android.source.SourceProvider.sourceModel"
+
+        /**
+         * Well-known [infoGroup] shared by the phone plugins (sensors, bluetooth, contacts,
+         * location, usage) so they are described together on the single visible phone row.
+         */
+        const val PHONE_INFO_GROUP = "phone"
 
         private val logger = LoggerFactory.getLogger(SourceProvider::class.java)
     }

--- a/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
+++ b/radar-commons-android/src/main/java/org/radarbase/android/util/PermissionHandler.kt
@@ -43,7 +43,6 @@ open class PermissionHandler(
     private var isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
     private var requestFuture: SafeHandler.HandlerFuture? = null
     private var isShowingDialog = false
-    private var awaitingExternalCallback = false
 
     private fun onPermissionRequestResult(permission: String, granted: Boolean) {
         mHandler.execute {
@@ -190,7 +189,6 @@ open class PermissionHandler(
                 permissions.toTypedArray(),
                 REQUEST_ENABLE_PERMISSIONS,
             )
-            mHandler.execute { awaitingExternalCallback = true }
         } catch (ex: IllegalStateException) {
             logger.warn("Cannot request permission on closing activity")
         }
@@ -200,7 +198,6 @@ open class PermissionHandler(
         isRequestingPermissions.clear()
         isRequestingPermissionsTime = java.lang.Long.MAX_VALUE
         isShowingDialog = false
-        awaitingExternalCallback = false
     }
 
     private fun addRequestingPermissions(permission: String) {
@@ -282,7 +279,6 @@ open class PermissionHandler(
         resolveActivity(activity.packageManager) ?: return
         try {
             activity.startActivityForResult(this, code)
-            mHandler.execute { awaitingExternalCallback = true }
         } catch (ex: ActivityNotFoundException) {
             logger.error("Failed to ask for usage code", ex)
         } catch (ex: IllegalStateException) {
@@ -327,7 +323,6 @@ open class PermissionHandler(
     }
 
     fun onActivityResult(requestCode: Int, resultCode: Int) {
-        mHandler.execute { awaitingExternalCallback = false }
         when (requestCode) {
             LOCATION_REQUEST_CODE -> onPermissionRequestResult(
                 LOCATION_SERVICE,
@@ -354,34 +349,13 @@ open class PermissionHandler(
         }
     }
 
-    fun onActivityResumed() {
-        mHandler.execute {
-            if (!isShowingDialog || !awaitingExternalCallback) return@execute
-            val pending = isRequestingPermissions.toSet()
-            pending.forEach { permission ->
-                val granted = activity.isPermissionGranted(permission)
-                needsPermissions.remove(permission)
-                broadcaster.send(RadarService.ACTION_PERMISSIONS_GRANTED) {
-                    putExtra(RadarService.EXTRA_PERMISSIONS, arrayOf(permission))
-                    putExtra(
-                        RadarService.EXTRA_GRANT_RESULTS,
-                        intArrayOf(if (granted) PERMISSION_GRANTED else PERMISSION_DENIED),
-                    )
-                }
-                isRequestingPermissions.remove(permission)
-            }
-            isShowingDialog = false
-            awaitingExternalCallback = false
-            requestPermissions()
-        }
-    }
-
     fun invalidateCache() {
         mHandler.execute {
             if (isRequestingPermissions.isNotEmpty()) {
                 val timeToExpire = isRequestingPermissionsTime + requestPermissionTimeoutMs - System.currentTimeMillis()
                 if (timeToExpire <= 0L) {
                     resetRequestingPermission()
+                    requestPermissions()
                 } else {
                     mHandler.delay(timeToExpire, ::resetRequestingPermission)
                 }
@@ -414,7 +388,6 @@ open class PermissionHandler(
             }
             mHandler.execute {
                 isShowingDialog = false
-                awaitingExternalCallback = false
                 requestPermissions()
             }
         }

--- a/radar-commons-android/src/main/res/values/strings.xml
+++ b/radar-commons-android/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">RADAR common android app</string>
 
     <string name="service_notification_ticker">Data Collection</string>
-    <string name="service_notification_text">Collecting data from connected sources</string>
+    <string name="service_notification_text">Your phone and any connected devices are sending study data in the background. Collection continues so the study keeps receiving your data.</string>
     <string name="service_notification_title">Data Collection in Progress</string>
 
     <string name="filter_split_regex">,</string>


### PR DESCRIPTION
This release include work from PRs:

- [Recover permission flow when Settings doesn't report a return](https://github.com/RADAR-base/radar-commons-android/pull/507)
- [Promote the radar service to foreground only after permissions are granted](https://github.com/RADAR-base/radar-commons-android/pull/508)
- [Fix crash when granting multiple permissions in sequence](https://github.com/RADAR-base/radar-commons-android/pull/509)
- [Polar plugin conditional UI support for making bluetooth scanning user perceptible](https://github.com/RADAR-base/radar-commons-android/pull/510)
- [Narrow foreground service types and add grouped source info](https://github.com/RADAR-base/radar-commons-android/pull/511)
- [Use project data from non conditional config and auth state](https://github.com/RADAR-base/radar-commons-android/pull/512)
- [Update the notification text to make it more explicit](https://github.com/RADAR-base/radar-commons-android/pull/513)